### PR TITLE
Custom import order separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,11 @@ A collection of Regular expressions in string format.
 "importOrder": ["^@core/(.*)$", "^@server/(.*)$", "^@ui/(.*)$", "^[./]"],
 ```
 
-_Default behavior:_ The plugin moves the third party imports to the top which are not part of the `importOrder` list.
+_Default:_ `[]`
+
+By default, this plugin will not move any imports. To separate third party from relative imports, use `["^[./]"]`. This will become the default in the next major version.
+
+The plugin moves the third party imports to the top which are not part of the `importOrder` list.
 To move the third party imports at desired place, you can use `<THIRD_PARTY_MODULES>` to assign third party imports to the appropriate position:
 
 ```json
@@ -147,6 +151,18 @@ between sorted import declarations group. The separation takes place according t
 
 ```json
 "importOrderSeparation": true,
+```
+
+_Note:_ If you want greater control over which groups are separated from others, you can add an empty string to your `importOrder` array to signify newlines. For example:
+
+```js
+"importOrderSeparation": false,
+"importOrder": [
+   "^react", // React will be placed at the top of third-party modules
+    "<THIRD_PARTY_MODULES>",
+    "",  // use empty strings to separate groups with empty lines
+    "^[./]"
+],
 ```
 
 #### `importOrderSortSpecifiers`

--- a/src/utils/__tests__/adjust-comments-on-sorted-nodes.spec.ts
+++ b/src/utils/__tests__/adjust-comments-on-sorted-nodes.spec.ts
@@ -1,13 +1,12 @@
-import { ImportDeclaration } from '@babel/types';
-
+import type { ImportOrLine } from '../../types';
 import { adjustCommentsOnSortedNodes } from '../adjust-comments-on-sorted-nodes';
 import { getImportNodes } from '../get-import-nodes';
 
-function leadingComments(node: ImportDeclaration): string[] {
+function leadingComments(node: ImportOrLine): string[] {
     return node.leadingComments?.map((c) => c.value) ?? [];
 }
 
-function trailingComments(node: ImportDeclaration): string[] {
+function trailingComments(node: ImportOrLine): string[] {
     return node.trailingComments?.map((c) => c.value) ?? [];
 }
 
@@ -21,14 +20,14 @@ test('it preserves the single leading comment for each import declaration', () =
     `);
     expect(importNodes).toHaveLength(3);
     const finalNodes = [importNodes[2], importNodes[1], importNodes[0]];
-    adjustCommentsOnSortedNodes(importNodes, finalNodes);
-    expect(finalNodes).toHaveLength(3);
-    expect(leadingComments(finalNodes[0])).toEqual([' comment a']);
-    expect(trailingComments(finalNodes[0])).toEqual([]);
-    expect(leadingComments(finalNodes[1])).toEqual([' comment b']);
-    expect(trailingComments(finalNodes[1])).toEqual([]);
-    expect(leadingComments(finalNodes[2])).toEqual([]);
-    expect(trailingComments(finalNodes[2])).toEqual([]);
+    const adjustedNodes = adjustCommentsOnSortedNodes(importNodes, finalNodes);
+    expect(adjustedNodes).toHaveLength(3);
+    expect(leadingComments(adjustedNodes[0])).toEqual([' comment a']);
+    expect(trailingComments(adjustedNodes[0])).toEqual([]);
+    expect(leadingComments(adjustedNodes[1])).toEqual([' comment b']);
+    expect(trailingComments(adjustedNodes[1])).toEqual([]);
+    expect(leadingComments(adjustedNodes[2])).toEqual([]);
+    expect(trailingComments(adjustedNodes[2])).toEqual([]);
 });
 
 test('it preserves multiple leading comments for each import declaration', () => {
@@ -45,22 +44,22 @@ test('it preserves multiple leading comments for each import declaration', () =>
     `);
     expect(importNodes).toHaveLength(3);
     const finalNodes = [importNodes[2], importNodes[1], importNodes[0]];
-    adjustCommentsOnSortedNodes(importNodes, finalNodes);
-    expect(finalNodes).toHaveLength(3);
-    expect(leadingComments(finalNodes[0])).toEqual([
+    const adjustedNodes = adjustCommentsOnSortedNodes(importNodes, finalNodes);
+    expect(adjustedNodes).toHaveLength(3);
+    expect(leadingComments(adjustedNodes[0])).toEqual([
         ' comment a1',
         ' comment a2',
         ' comment a3',
     ]);
-    expect(trailingComments(finalNodes[0])).toEqual([]);
-    expect(leadingComments(finalNodes[1])).toEqual([
+    expect(trailingComments(adjustedNodes[0])).toEqual([]);
+    expect(leadingComments(adjustedNodes[1])).toEqual([
         ' comment b1',
         ' comment b2',
         ' comment b3',
     ]);
-    expect(trailingComments(finalNodes[1])).toEqual([]);
-    expect(leadingComments(finalNodes[2])).toEqual([]);
-    expect(trailingComments(finalNodes[2])).toEqual([]);
+    expect(trailingComments(adjustedNodes[1])).toEqual([]);
+    expect(leadingComments(adjustedNodes[2])).toEqual([]);
+    expect(trailingComments(adjustedNodes[2])).toEqual([]);
 });
 
 test('it does not move comments at before all import declarations', () => {
@@ -73,17 +72,17 @@ test('it does not move comments at before all import declarations', () => {
     `);
     expect(importNodes).toHaveLength(3);
     const finalNodes = [importNodes[2], importNodes[1], importNodes[0]];
-    adjustCommentsOnSortedNodes(importNodes, finalNodes);
-    expect(finalNodes).toHaveLength(3);
-    expect(leadingComments(finalNodes[0])).toEqual([
+    const adjustedNodes = adjustCommentsOnSortedNodes(importNodes, finalNodes);
+    expect(adjustedNodes).toHaveLength(3);
+    expect(leadingComments(adjustedNodes[0])).toEqual([
         ' comment c1',
         ' comment c2',
     ]);
-    expect(trailingComments(finalNodes[0])).toEqual([]);
-    expect(leadingComments(finalNodes[1])).toEqual([]);
-    expect(trailingComments(finalNodes[1])).toEqual([]);
-    expect(leadingComments(finalNodes[2])).toEqual([]);
-    expect(trailingComments(finalNodes[2])).toEqual([]);
+    expect(trailingComments(adjustedNodes[0])).toEqual([]);
+    expect(leadingComments(adjustedNodes[1])).toEqual([]);
+    expect(trailingComments(adjustedNodes[1])).toEqual([]);
+    expect(leadingComments(adjustedNodes[2])).toEqual([]);
+    expect(trailingComments(adjustedNodes[2])).toEqual([]);
 });
 
 test('it does not affect comments after all import declarations', () => {
@@ -96,12 +95,12 @@ test('it does not affect comments after all import declarations', () => {
     `);
     expect(importNodes).toHaveLength(3);
     const finalNodes = [importNodes[2], importNodes[1], importNodes[0]];
-    adjustCommentsOnSortedNodes(importNodes, finalNodes);
-    expect(finalNodes).toHaveLength(3);
-    expect(leadingComments(finalNodes[0])).toEqual([]);
-    expect(trailingComments(finalNodes[0])).toEqual([]);
-    expect(leadingComments(finalNodes[1])).toEqual([]);
-    expect(trailingComments(finalNodes[1])).toEqual([]);
-    expect(leadingComments(finalNodes[2])).toEqual([]);
-    expect(trailingComments(finalNodes[2])).toEqual([]);
+    const adjustedNodes = adjustCommentsOnSortedNodes(importNodes, finalNodes);
+    expect(adjustedNodes).toHaveLength(3);
+    expect(leadingComments(adjustedNodes[0])).toEqual([]);
+    expect(trailingComments(adjustedNodes[0])).toEqual([]);
+    expect(leadingComments(adjustedNodes[1])).toEqual([]);
+    expect(trailingComments(adjustedNodes[1])).toEqual([]);
+    expect(leadingComments(adjustedNodes[2])).toEqual([]);
+    expect(trailingComments(adjustedNodes[2])).toEqual([]);
 });

--- a/src/utils/__tests__/get-sorted-nodes-by-import-order.spec.ts
+++ b/src/utils/__tests__/get-sorted-nodes-by-import-order.spec.ts
@@ -488,3 +488,82 @@ test('it adds newlines when importOrderSeparation is true', () => {
         '',
     ]);
 });
+
+test('it returns all sorted nodes with custom separation', () => {
+    const result = getImportNodes(code);
+    const sorted = getSortedNodesByImportOrder(result, {
+        importOrder: [
+            '^a$',
+            '<THIRD_PARTY_MODULES>',
+            '^t$',
+            '',
+            '^k$',
+            '^[./]',
+        ],
+        importOrderSeparation: false,
+        importOrderCaseInsensitive: true,
+        importOrderGroupNamespaceSpecifiers: false,
+        importOrderSortSpecifiers: false,
+        importOrderBuiltinModulesToTop: false,
+    }) as ImportDeclaration[];
+    expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
+        'a',
+        'Ba',
+        'BY',
+        'c',
+        'g',
+        'node:fs/promises',
+        'node:url',
+        'path',
+        'x',
+        'Xa',
+        'XY',
+        'z',
+        't',
+        '',
+        'k',
+        './local',
+    ]);
+});
+
+test('it allows both importOrderSeparation and custom separation (but why?)', () => {
+    const result = getImportNodes(code);
+    const sorted = getSortedNodesByImportOrder(result, {
+        importOrder: [
+            '^a$',
+            '<THIRD_PARTY_MODULES>',
+            '^t$',
+            '',
+            '^k$',
+            '^[./]',
+        ],
+        importOrderSeparation: true,
+        importOrderCaseInsensitive: true,
+        importOrderGroupNamespaceSpecifiers: false,
+        importOrderSortSpecifiers: false,
+        importOrderBuiltinModulesToTop: false,
+    }) as ImportDeclaration[];
+    expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
+        'a',
+        '',
+        'Ba',
+        'BY',
+        'c',
+        'g',
+        'node:fs/promises',
+        'node:url',
+        'path',
+        'x',
+        'Xa',
+        'XY',
+        'z',
+        '',
+        't',
+        '',
+        '',
+        'k',
+        '',
+        './local',
+        '',
+    ]);
+});

--- a/src/utils/__tests__/get-sorted-nodes-by-import-order.spec.ts
+++ b/src/utils/__tests__/get-sorted-nodes-by-import-order.spec.ts
@@ -560,10 +560,48 @@ test('it allows both importOrderSeparation and custom separation (but why?)', ()
         '',
         't',
         '',
-        '',
         'k',
         '',
         './local',
         '',
+    ]);
+});
+
+test('it does not add multiple custom import separators', () => {
+    const result = getImportNodes(code);
+    const sorted = getSortedNodesByImportOrder(result, {
+        importOrder: [
+            '^a$',
+            '<THIRD_PARTY_MODULES>',
+            '^t$',
+            '',
+            'notfound',
+            '',
+            '^k$',
+            '^[./]',
+        ],
+        importOrderSeparation: false,
+        importOrderCaseInsensitive: true,
+        importOrderGroupNamespaceSpecifiers: false,
+        importOrderSortSpecifiers: false,
+        importOrderBuiltinModulesToTop: false,
+    }) as ImportDeclaration[];
+    expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
+        'a',
+        'Ba',
+        'BY',
+        'c',
+        'g',
+        'node:fs/promises',
+        'node:url',
+        'path',
+        'x',
+        'Xa',
+        'XY',
+        'z',
+        't',
+        '',
+        'k',
+        './local',
     ]);
 });

--- a/src/utils/__tests__/get-sorted-nodes-by-import-order.spec.ts
+++ b/src/utils/__tests__/get-sorted-nodes-by-import-order.spec.ts
@@ -1,9 +1,9 @@
 import { ImportDeclaration } from '@babel/types';
 
 import { getImportNodes } from '../get-import-nodes';
-import { getSortedNodes } from '../get-sorted-nodes';
+import { getSortedNodesByImportOrder } from '../get-sorted-nodes-by-import-order';
 import { getSortedNodesModulesNames } from '../get-sorted-nodes-modules-names';
-import { getSortedNodesNames } from '../get-sorted-nodes-names';
+import { getSortedNodesNamesAndNewlines } from '../get-sorted-nodes-names-and-newlines';
 
 const code = `// first comment
 // second comment
@@ -13,6 +13,7 @@ import g from 'g';
 import { tC, tA, tB } from 't';
 import k, { kE, kB } from 'k';
 import * as a from 'a';
+import * as local from './local';
 import * as x from 'x';
 import path from 'path';
 import url from 'node:url';
@@ -25,8 +26,8 @@ import Xa from 'Xa';
 
 test('it returns all sorted nodes', () => {
     const result = getImportNodes(code);
-    const sorted = getSortedNodes(result, {
-        importOrder: [],
+    const sorted = getSortedNodesByImportOrder(result, {
+        importOrder: ['^[./]'],
         importOrderCaseInsensitive: false,
         importOrderSeparation: false,
         importOrderGroupNamespaceSpecifiers: false,
@@ -34,7 +35,7 @@ test('it returns all sorted nodes', () => {
         importOrderBuiltinModulesToTop: false,
     }) as ImportDeclaration[];
 
-    expect(getSortedNodesNames(sorted)).toEqual([
+    expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
         'BY',
         'Ba',
         'XY',
@@ -49,6 +50,7 @@ test('it returns all sorted nodes', () => {
         't',
         'x',
         'z',
+        './local',
     ]);
     expect(
         sorted
@@ -71,13 +73,14 @@ test('it returns all sorted nodes', () => {
         ['tC', 'tA', 'tB'],
         ['x'],
         ['z'],
+        ['local'],
     ]);
 });
 
 test('it returns all sorted nodes case-insensitive', () => {
     const result = getImportNodes(code);
-    const sorted = getSortedNodes(result, {
-        importOrder: [],
+    const sorted = getSortedNodesByImportOrder(result, {
+        importOrder: ['^[./]'],
         importOrderCaseInsensitive: true,
         importOrderSeparation: false,
         importOrderGroupNamespaceSpecifiers: false,
@@ -85,7 +88,7 @@ test('it returns all sorted nodes case-insensitive', () => {
         importOrderBuiltinModulesToTop: false,
     }) as ImportDeclaration[];
 
-    expect(getSortedNodesNames(sorted)).toEqual([
+    expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
         'a',
         'Ba',
         'BY',
@@ -100,6 +103,7 @@ test('it returns all sorted nodes case-insensitive', () => {
         'Xa',
         'XY',
         'z',
+        './local',
     ]);
     expect(
         sorted
@@ -122,13 +126,14 @@ test('it returns all sorted nodes case-insensitive', () => {
         ['Xa'],
         ['XY'],
         ['z'],
+        ['local'],
     ]);
 });
 
 test('it returns all sorted nodes with sort order', () => {
     const result = getImportNodes(code);
-    const sorted = getSortedNodes(result, {
-        importOrder: ['^a$', '^t$', '^k$', '^B'],
+    const sorted = getSortedNodesByImportOrder(result, {
+        importOrder: ['^a$', '^t$', '^k$', '^B', '^[./]'],
         importOrderCaseInsensitive: false,
         importOrderSeparation: false,
         importOrderGroupNamespaceSpecifiers: false,
@@ -136,7 +141,7 @@ test('it returns all sorted nodes with sort order', () => {
         importOrderBuiltinModulesToTop: false,
     }) as ImportDeclaration[];
 
-    expect(getSortedNodesNames(sorted)).toEqual([
+    expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
         'XY',
         'Xa',
         'c',
@@ -151,6 +156,7 @@ test('it returns all sorted nodes with sort order', () => {
         'k',
         'BY',
         'Ba',
+        './local',
     ]);
     expect(
         sorted
@@ -173,20 +179,21 @@ test('it returns all sorted nodes with sort order', () => {
         ['k', 'kE', 'kB'],
         ['BY'],
         ['Ba'],
+        ['local'],
     ]);
 });
 
 test('it returns all sorted nodes with sort order case-insensitive', () => {
     const result = getImportNodes(code);
-    const sorted = getSortedNodes(result, {
-        importOrder: ['^a$', '^t$', '^k$', '^B'],
+    const sorted = getSortedNodesByImportOrder(result, {
+        importOrder: ['^a$', '^t$', '^k$', '^B', '^[./]'],
         importOrderCaseInsensitive: true,
         importOrderSeparation: false,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderSortSpecifiers: false,
         importOrderBuiltinModulesToTop: false,
     }) as ImportDeclaration[];
-    expect(getSortedNodesNames(sorted)).toEqual([
+    expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
         'c',
         'g',
         'node:fs/promises',
@@ -201,6 +208,7 @@ test('it returns all sorted nodes with sort order case-insensitive', () => {
         'k',
         'Ba',
         'BY',
+        './local',
     ]);
     expect(
         sorted
@@ -223,20 +231,21 @@ test('it returns all sorted nodes with sort order case-insensitive', () => {
         ['k', 'kE', 'kB'],
         ['Ba'],
         ['BY'],
+        ['local'],
     ]);
 });
 
 test('it returns all sorted import nodes with sorted import specifiers', () => {
     const result = getImportNodes(code);
-    const sorted = getSortedNodes(result, {
-        importOrder: ['^a$', '^t$', '^k$', '^B'],
+    const sorted = getSortedNodesByImportOrder(result, {
+        importOrder: ['^a$', '^t$', '^k$', '^B', '^[./]'],
         importOrderCaseInsensitive: false,
         importOrderSeparation: false,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderSortSpecifiers: true,
         importOrderBuiltinModulesToTop: false,
     }) as ImportDeclaration[];
-    expect(getSortedNodesNames(sorted)).toEqual([
+    expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
         'XY',
         'Xa',
         'c',
@@ -251,6 +260,7 @@ test('it returns all sorted import nodes with sorted import specifiers', () => {
         'k',
         'BY',
         'Ba',
+        './local',
     ]);
     expect(
         sorted
@@ -273,20 +283,21 @@ test('it returns all sorted import nodes with sorted import specifiers', () => {
         ['k', 'kB', 'kE'],
         ['BY'],
         ['Ba'],
+        ['local'],
     ]);
 });
 
 test('it returns all sorted import nodes with sorted import specifiers with case-insensitive ', () => {
     const result = getImportNodes(code);
-    const sorted = getSortedNodes(result, {
-        importOrder: ['^a$', '^t$', '^k$', '^B'],
+    const sorted = getSortedNodesByImportOrder(result, {
+        importOrder: ['^a$', '^t$', '^k$', '^B', '^[./]'],
         importOrderCaseInsensitive: true,
         importOrderSeparation: false,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderSortSpecifiers: true,
         importOrderBuiltinModulesToTop: false,
     }) as ImportDeclaration[];
-    expect(getSortedNodesNames(sorted)).toEqual([
+    expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
         'c',
         'g',
         'node:fs/promises',
@@ -301,6 +312,7 @@ test('it returns all sorted import nodes with sorted import specifiers with case
         'k',
         'Ba',
         'BY',
+        './local',
     ]);
     expect(
         sorted
@@ -323,20 +335,21 @@ test('it returns all sorted import nodes with sorted import specifiers with case
         ['k', 'kB', 'kE'],
         ['Ba'],
         ['BY'],
+        ['local'],
     ]);
 });
 
 test('it returns all sorted nodes with custom third party modules', () => {
     const result = getImportNodes(code);
-    const sorted = getSortedNodes(result, {
-        importOrder: ['^a$', '<THIRD_PARTY_MODULES>', '^t$', '^k$'],
+    const sorted = getSortedNodesByImportOrder(result, {
+        importOrder: ['^a$', '<THIRD_PARTY_MODULES>', '^t$', '^k$', '^[./]'],
         importOrderSeparation: false,
         importOrderCaseInsensitive: true,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderSortSpecifiers: false,
         importOrderBuiltinModulesToTop: false,
     }) as ImportDeclaration[];
-    expect(getSortedNodesNames(sorted)).toEqual([
+    expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
         'a',
         'Ba',
         'BY',
@@ -351,13 +364,14 @@ test('it returns all sorted nodes with custom third party modules', () => {
         'z',
         't',
         'k',
+        './local',
     ]);
 });
 
 test('it returns all sorted nodes with namespace specifiers at the top', () => {
     const result = getImportNodes(code);
-    const sorted = getSortedNodes(result, {
-        importOrder: [],
+    const sorted = getSortedNodesByImportOrder(result, {
+        importOrder: ['^[./]'],
         importOrderCaseInsensitive: false,
         importOrderSeparation: false,
         importOrderGroupNamespaceSpecifiers: true,
@@ -365,7 +379,7 @@ test('it returns all sorted nodes with namespace specifiers at the top', () => {
         importOrderBuiltinModulesToTop: false,
     }) as ImportDeclaration[];
 
-    expect(getSortedNodesNames(sorted)).toEqual([
+    expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
         'a',
         'node:fs/promises',
         'x',
@@ -380,13 +394,14 @@ test('it returns all sorted nodes with namespace specifiers at the top', () => {
         'path',
         't',
         'z',
+        './local',
     ]);
 });
 
 test('it returns all sorted nodes with builtin specifiers at the top, ', () => {
     const result = getImportNodes(code);
-    const sorted = getSortedNodes(result, {
-        importOrder: [],
+    const sorted = getSortedNodesByImportOrder(result, {
+        importOrder: ['^[./]'],
         importOrderCaseInsensitive: false,
         importOrderSeparation: false,
         importOrderGroupNamespaceSpecifiers: false,
@@ -394,7 +409,7 @@ test('it returns all sorted nodes with builtin specifiers at the top, ', () => {
         importOrderBuiltinModulesToTop: true,
     }) as ImportDeclaration[];
 
-    expect(getSortedNodesNames(sorted)).toEqual([
+    expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
         'node:fs/promises',
         'node:url',
         'path',
@@ -409,20 +424,21 @@ test('it returns all sorted nodes with builtin specifiers at the top, ', () => {
         't',
         'x',
         'z',
+        './local',
     ]);
 });
 
 test('it returns all sorted nodes with custom third party modules and builtins at top', () => {
     const result = getImportNodes(code);
-    const sorted = getSortedNodes(result, {
-        importOrder: ['^a$', '<THIRD_PARTY_MODULES>', '^t$', '^k$'],
+    const sorted = getSortedNodesByImportOrder(result, {
+        importOrder: ['^a$', '<THIRD_PARTY_MODULES>', '^t$', '^k$', '^[./]'],
         importOrderSeparation: false,
         importOrderCaseInsensitive: true,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderSortSpecifiers: false,
         importOrderBuiltinModulesToTop: true,
     }) as ImportDeclaration[];
-    expect(getSortedNodesNames(sorted)).toEqual([
+    expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
         'node:fs/promises',
         'node:url',
         'path',
@@ -437,5 +453,38 @@ test('it returns all sorted nodes with custom third party modules and builtins a
         'z',
         't',
         'k',
+        './local',
+    ]);
+});
+
+test('it adds newlines when importOrderSeparation is true', () => {
+    const result = getImportNodes(code);
+    const sorted = getSortedNodesByImportOrder(result, {
+        importOrder: ['^[./]'],
+        importOrderSeparation: true,
+        importOrderCaseInsensitive: true,
+        importOrderGroupNamespaceSpecifiers: false,
+        importOrderSortSpecifiers: false,
+        importOrderBuiltinModulesToTop: true,
+    }) as ImportDeclaration[];
+    expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
+        'node:fs/promises',
+        'node:url',
+        'path',
+        '',
+        'a',
+        'Ba',
+        'BY',
+        'c',
+        'g',
+        'k',
+        't',
+        'x',
+        'Xa',
+        'XY',
+        'z',
+        '',
+        './local',
+        '',
     ]);
 });

--- a/src/utils/__tests__/get-sorted-nodes.spec.ts
+++ b/src/utils/__tests__/get-sorted-nodes.spec.ts
@@ -3,7 +3,7 @@ import { ImportDeclaration } from '@babel/types';
 import { getImportNodes } from '../get-import-nodes';
 import { getSortedNodes } from '../get-sorted-nodes';
 import { getSortedNodesModulesNames } from '../get-sorted-nodes-modules-names';
-import { getSortedNodesNames } from '../get-sorted-nodes-names';
+import { getSortedNodesNamesAndNewlines } from '../get-sorted-nodes-names-and-newlines';
 
 const code = `// first comment
 // second comment
@@ -36,7 +36,7 @@ test('it returns all sorted nodes, preserving the order side effect nodes', () =
         importOrderBuiltinModulesToTop: false,
     }) as ImportDeclaration[];
 
-    expect(getSortedNodesNames(sorted)).toEqual([
+    expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
         'se3',
         'c',
         'g',
@@ -53,6 +53,7 @@ test('it returns all sorted nodes, preserving the order side effect nodes', () =
         'path',
         'x',
         'se2',
+        '',
     ]);
     expect(
         sorted

--- a/src/utils/adjust-comments-on-sorted-nodes.ts
+++ b/src/utils/adjust-comments-on-sorted-nodes.ts
@@ -9,31 +9,30 @@ import { ImportOrLine } from '../types';
  * they were in the original nodes.
  * @param nodes A list of nodes in the order as they were originally.
  * @param finalNodes The same set of nodes, but in the final sorting order.
+ * @returns A copied and adjusted set of nodes, containing comments
  */
 export const adjustCommentsOnSortedNodes = (
     nodes: ImportDeclaration[],
     finalNodes: ImportOrLine[],
 ) => {
-    // maintain a copy of the nodes to extract comments from
+    // We will mutate a copy of the finalNodes, and extract comments from the original
     const finalNodesClone = finalNodes.map(clone);
 
     const firstNodesComments = nodes[0].leadingComments;
 
     // Remove all comments from sorted nodes
-    finalNodes.forEach(removeComments);
+    finalNodesClone.forEach(removeComments);
 
     // insert comments other than the first comments
-    finalNodes.forEach((node, index) => {
+    finalNodesClone.forEach((node, index) => {
         if (isEqual(nodes[0].loc, node.loc)) return;
 
-        addComments(
-            node,
-            'leading',
-            finalNodesClone[index].leadingComments || [],
-        );
+        addComments(node, 'leading', finalNodes[index].leadingComments || []);
     });
 
     if (firstNodesComments) {
-        addComments(finalNodes[0], 'leading', firstNodesComments);
+        addComments(finalNodesClone[0], 'leading', firstNodesComments);
     }
+
+    return finalNodesClone;
 };

--- a/src/utils/get-sorted-nodes-by-import-order.ts
+++ b/src/utils/get-sorted-nodes-by-import-order.ts
@@ -70,6 +70,10 @@ export const getSortedNodesByImportOrder: GetSortedNodes = (nodes, options) => {
     for (const group of importOrder) {
         // If it's a custom separator, all we need to do is add a newline
         if (isCustomGroupSeparator(group)) {
+            // Don't add multiple newlines
+            if (isLastNodeANewline(finalNodes)) {
+                continue;
+            }
             finalNodes.push(newLineNode);
             continue;
         }
@@ -105,4 +109,9 @@ export const getSortedNodesByImportOrder: GetSortedNodes = (nodes, options) => {
  */
 function isCustomGroupSeparator(pattern: string) {
     return pattern.trim() === '';
+}
+
+function isLastNodeANewline(nodes: ImportOrLine[]) {
+    const lastNode = nodes[nodes.length - 1];
+    return lastNode?.type === 'ExpressionStatement';
 }

--- a/src/utils/get-sorted-nodes-names-and-newlines.ts
+++ b/src/utils/get-sorted-nodes-names-and-newlines.ts
@@ -1,0 +1,21 @@
+import { ExpressionStatement, ImportDeclaration } from '@babel/types';
+
+/**
+ * Test helper, to verify sort order and newline placement
+ */
+export const getSortedNodesNamesAndNewlines = (
+    imports: (ImportDeclaration | ExpressionStatement)[],
+) =>
+    imports
+        .filter(
+            (i) =>
+                i.type === 'ImportDeclaration' ||
+                i.type === 'ExpressionStatement',
+        )
+        .map((i) => {
+            if (i.type === 'ImportDeclaration') {
+                return i.source.value;
+            } else {
+                return '';
+            }
+        });

--- a/src/utils/get-sorted-nodes-names.ts
+++ b/src/utils/get-sorted-nodes-names.ts
@@ -1,6 +1,0 @@
-import { ImportDeclaration } from '@babel/types';
-
-export const getSortedNodesNames = (imports: ImportDeclaration[]) =>
-    imports
-        .filter((i) => i.type === 'ImportDeclaration')
-        .map((i) => i.source.value); // TODO: get from specifier

--- a/src/utils/get-sorted-nodes.ts
+++ b/src/utils/get-sorted-nodes.ts
@@ -1,4 +1,4 @@
-import { chunkTypeOther, chunkTypeUnsortable, newLineNode } from '../constants';
+import { chunkTypeUnsortable, newLineNode } from '../constants';
 import { GetSortedNodes, ImportChunk, ImportOrLine } from '../types';
 import { adjustCommentsOnSortedNodes } from './adjust-comments-on-sorted-nodes';
 import { getChunkTypeOfNode } from './get-chunk-type-of-node';

--- a/src/utils/get-sorted-nodes.ts
+++ b/src/utils/get-sorted-nodes.ts
@@ -62,7 +62,5 @@ export const getSortedNodes: GetSortedNodes = (
     }
 
     // Adjust the comments on the sorted nodes to match the original comments
-    adjustCommentsOnSortedNodes(nodes, finalNodes);
-
-    return finalNodes;
+    return adjustCommentsOnSortedNodes(nodes, finalNodes);
 };

--- a/test-setup/run_spec.js
+++ b/test-setup/run_spec.js
@@ -60,34 +60,6 @@ function run_spec(dirname, parsers, options) {
 }
 global.run_spec = run_spec;
 
-function stripLocation(ast) {
-    if (Array.isArray(ast)) {
-        return ast.map((e) => stripLocation(e));
-    }
-    if (typeof ast === 'object') {
-        const newObj = {};
-        for (const key in ast) {
-            if (
-                key === 'loc' ||
-                key === 'range' ||
-                key === 'raw' ||
-                key === 'comments' ||
-                key === 'parent' ||
-                key === 'prev'
-            ) {
-                continue;
-            }
-            newObj[key] = stripLocation(ast[key]);
-        }
-        return newObj;
-    }
-    return ast;
-}
-
-function parse(string, opts) {
-    return stripLocation(prettier.__debug.parse(string, opts));
-}
-
 function prettyprint(src, filename, options) {
     return prettier.format(
         src,

--- a/tests/ImportsSeparatedByEmptyRegex/__snapshots__/ppsi.spec.js.snap
+++ b/tests/ImportsSeparatedByEmptyRegex/__snapshots__/ppsi.spec.js.snap
@@ -1,0 +1,307 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`import-export-in-between.ts - typescript-verify: import-export-in-between.ts 1`] = `
+import threeLevelRelativePath from "../../../threeLevelRelativePath";
+import sameLevelRelativePath from "./sameLevelRelativePath";
+import thirdParty from "third-party";
+export { random } from './random';
+import c from 'c';
+import oneLevelRelativePath from "../oneLevelRelativePath";
+import otherthing from "@core/otherthing";
+import a from 'a';
+import twoLevelRelativePath from "../../twoLevelRelativePath";
+import component from "@ui/hello";
+export default {
+    title: 'hello',
+};
+import fourLevelRelativePath from "../../../../fourLevelRelativePath";
+import something from "@server/something";
+import x from 'x';
+
+function add(a:number,b:number) {
+  return a + b;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import a from "a";
+import c from "c";
+import thirdParty from "third-party";
+import x from "x";
+
+import otherthing from "@core/otherthing";
+import something from "@server/something";
+import component from "@ui/hello";
+
+import fourLevelRelativePath from "../../../../fourLevelRelativePath";
+import threeLevelRelativePath from "../../../threeLevelRelativePath";
+import twoLevelRelativePath from "../../twoLevelRelativePath";
+import oneLevelRelativePath from "../oneLevelRelativePath";
+import sameLevelRelativePath from "./sameLevelRelativePath";
+
+export { random } from "./random";
+
+export default {
+    title: "hello",
+};
+
+function add(a: number, b: number) {
+    return a + b;
+}
+
+`;
+
+exports[`import-export-only.ts - typescript-verify: import-export-only.ts 1`] = `
+import React from 'react';
+export const a = 1;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import React from "react";
+
+export const a = 1;
+
+`;
+
+exports[`imports-with-comments.ts - typescript-verify: imports-with-comments.ts 1`] = `
+// I am top level comment in this file.
+// I am second line of top level comment in this file.
+import './commands';
+
+// Comment
+// Comment
+
+function add(a:number,b:number) {
+    return a + b;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// I am top level comment in this file.
+// I am second line of top level comment in this file.
+import "./commands";
+
+// Comment
+// Comment
+
+function add(a: number, b: number) {
+    return a + b;
+}
+
+`;
+
+exports[`imports-with-comments-and-third-party.ts - typescript-verify: imports-with-comments-and-third-party.ts 1`] = `
+// I am top level comment in this file.
+// I am second line of top level comment in this file.
+import './commands';
+import React from 'react';
+// Comment
+// Comment
+
+function add(a:number,b:number) {
+    return a + b;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// I am top level comment in this file.
+// I am second line of top level comment in this file.
+import React from "react";
+
+import "./commands";
+
+// Comment
+// Comment
+
+function add(a: number, b: number) {
+    return a + b;
+}
+
+`;
+
+exports[`imports-with-comments-on-top.ts - typescript-verify: imports-with-comments-on-top.ts 1`] = `
+// I am top level comment in this file.
+// I am second line of top level comment in this file.
+import z from 'z';
+import threeLevelRelativePath from "../../../threeLevelRelativePath";
+import sameLevelRelativePath from "./sameLevelRelativePath";
+import thirdParty from "third-party";
+import oneLevelRelativePath from "../oneLevelRelativePath";
+import otherthing from "@core/otherthing";
+import abc from "@core/abc";
+import twoLevelRelativePath from "../../twoLevelRelativePath";
+import component from "@ui/hello";
+import fourLevelRelativePath from "../../../../fourLevelRelativePath";
+import something from "@server/something";
+import xyz from "@ui/xyz";
+import qwerty from "@server/qwerty";
+
+function add(a:number,b:number) {
+  return a + b;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// I am top level comment in this file.
+// I am second line of top level comment in this file.
+import thirdParty from "third-party";
+import z from "z";
+
+import abc from "@core/abc";
+import otherthing from "@core/otherthing";
+import qwerty from "@server/qwerty";
+import something from "@server/something";
+import component from "@ui/hello";
+import xyz from "@ui/xyz";
+
+import fourLevelRelativePath from "../../../../fourLevelRelativePath";
+import threeLevelRelativePath from "../../../threeLevelRelativePath";
+import twoLevelRelativePath from "../../twoLevelRelativePath";
+import oneLevelRelativePath from "../oneLevelRelativePath";
+import sameLevelRelativePath from "./sameLevelRelativePath";
+
+function add(a: number, b: number) {
+    return a + b;
+}
+
+`;
+
+exports[`imports-with-file-level-comments.ts - typescript-verify: imports-with-file-level-comments.ts 1`] = `
+//@ts-ignore
+// I am file top level comments
+import threeLevelRelativePath from "../../../threeLevelRelativePath";
+// I am stick to sameLevelRelativePath
+import sameLevelRelativePath from "./sameLevelRelativePath";
+// I am stick to third party comment
+import thirdParty from "third-party";
+// leading comment
+import { 
+    random // inner comment
+} from './random';
+// leading comment
+export { 
+    random // inner comment
+} from './random';
+import c from 'c';
+import oneLevelRelativePath from "../oneLevelRelativePath";
+import otherthing from "@core/otherthing";
+import a from 'a';
+import twoLevelRelativePath from "../../twoLevelRelativePath";
+import component from "@ui/hello";
+export default {
+    title: 'hello',
+};
+import fourLevelRelativePath from "../../../../fourLevelRelativePath";
+import something from "@server/something";
+import x from 'x';
+
+// I am function comment
+
+function add(a:number,b:number) {
+  return a + b; // I am inside function 
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//@ts-ignore
+// I am file top level comments
+import a from "a";
+import c from "c";
+// I am stick to third party comment
+import thirdParty from "third-party";
+import x from "x";
+
+import otherthing from "@core/otherthing";
+import something from "@server/something";
+import component from "@ui/hello";
+
+import fourLevelRelativePath from "../../../../fourLevelRelativePath";
+import threeLevelRelativePath from "../../../threeLevelRelativePath";
+import twoLevelRelativePath from "../../twoLevelRelativePath";
+import oneLevelRelativePath from "../oneLevelRelativePath";
+// leading comment
+import {
+    random, // inner comment
+} from "./random";
+// I am stick to sameLevelRelativePath
+import sameLevelRelativePath from "./sameLevelRelativePath";
+
+// leading comment
+export {
+    random, // inner comment
+} from "./random";
+
+export default {
+    title: "hello",
+};
+
+// I am function comment
+
+function add(a: number, b: number) {
+    return a + b; // I am inside function
+}
+
+`;
+
+exports[`imports-without-third-party.ts - typescript-verify: imports-without-third-party.ts 1`] = `
+// I am top level comment
+import otherthing from "@core/otherthing";
+import abc from "@core/abc";
+// I am comment
+import twoLevelRelativePath from "../../twoLevelRelativePath";
+import component from "@ui/hello";
+import fourLevelRelativePath from "../../../../fourLevelRelativePath";
+import something from "@server/something";
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// I am top level comment
+import abc from "@core/abc";
+import otherthing from "@core/otherthing";
+import something from "@server/something";
+import component from "@ui/hello";
+
+import fourLevelRelativePath from "../../../../fourLevelRelativePath";
+// I am comment
+import twoLevelRelativePath from "../../twoLevelRelativePath";
+
+`;
+
+exports[`no-import-export.ts - typescript-verify: no-import-export.ts 1`] = `
+function add(a:number,b:number) {
+    return a + b;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+function add(a: number, b: number) {
+    return a + b;
+}
+
+`;
+
+exports[`one-import.ts - typescript-verify: one-import.ts 1`] = `
+// This example support/index.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands';
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// This example support/index.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+// Import commands.js using ES2015 syntax:
+import "./commands";
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')
+
+`;

--- a/tests/ImportsSeparatedByEmptyRegex/__snapshots__/ppsi.spec.js.snap
+++ b/tests/ImportsSeparatedByEmptyRegex/__snapshots__/ppsi.spec.js.snap
@@ -98,9 +98,8 @@ function add(a:number,b:number) {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
-import React from "react";
-
 import "./commands";
+import React from "react";
 
 // Comment
 // Comment
@@ -242,6 +241,7 @@ import fourLevelRelativePath from "../../../../fourLevelRelativePath";
 import something from "@server/something";
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // I am top level comment
+
 import abc from "@core/abc";
 import otherthing from "@core/otherthing";
 import something from "@server/something";
@@ -300,6 +300,7 @@ import './commands';
 // ***********************************************************
 // Import commands.js using ES2015 syntax:
 import "./commands";
+// I am top level comment
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/tests/ImportsSeparatedByEmptyRegex/__snapshots__/ppsi.spec.js.snap
+++ b/tests/ImportsSeparatedByEmptyRegex/__snapshots__/ppsi.spec.js.snap
@@ -300,7 +300,6 @@ import './commands';
 // ***********************************************************
 // Import commands.js using ES2015 syntax:
 import "./commands";
-// I am top level comment
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/tests/ImportsSeparatedByEmptyRegex/import-export-in-between.ts
+++ b/tests/ImportsSeparatedByEmptyRegex/import-export-in-between.ts
@@ -1,0 +1,20 @@
+import threeLevelRelativePath from "../../../threeLevelRelativePath";
+import sameLevelRelativePath from "./sameLevelRelativePath";
+import thirdParty from "third-party";
+export { random } from './random';
+import c from 'c';
+import oneLevelRelativePath from "../oneLevelRelativePath";
+import otherthing from "@core/otherthing";
+import a from 'a';
+import twoLevelRelativePath from "../../twoLevelRelativePath";
+import component from "@ui/hello";
+export default {
+    title: 'hello',
+};
+import fourLevelRelativePath from "../../../../fourLevelRelativePath";
+import something from "@server/something";
+import x from 'x';
+
+function add(a:number,b:number) {
+  return a + b;
+}

--- a/tests/ImportsSeparatedByEmptyRegex/import-export-only.ts
+++ b/tests/ImportsSeparatedByEmptyRegex/import-export-only.ts
@@ -1,0 +1,2 @@
+import React from 'react';
+export const a = 1;

--- a/tests/ImportsSeparatedByEmptyRegex/imports-with-comments-and-third-party.ts
+++ b/tests/ImportsSeparatedByEmptyRegex/imports-with-comments-and-third-party.ts
@@ -1,0 +1,10 @@
+// I am top level comment in this file.
+// I am second line of top level comment in this file.
+import './commands';
+import React from 'react';
+// Comment
+// Comment
+
+function add(a:number,b:number) {
+    return a + b;
+}

--- a/tests/ImportsSeparatedByEmptyRegex/imports-with-comments-on-top.ts
+++ b/tests/ImportsSeparatedByEmptyRegex/imports-with-comments-on-top.ts
@@ -1,0 +1,19 @@
+// I am top level comment in this file.
+// I am second line of top level comment in this file.
+import z from 'z';
+import threeLevelRelativePath from "../../../threeLevelRelativePath";
+import sameLevelRelativePath from "./sameLevelRelativePath";
+import thirdParty from "third-party";
+import oneLevelRelativePath from "../oneLevelRelativePath";
+import otherthing from "@core/otherthing";
+import abc from "@core/abc";
+import twoLevelRelativePath from "../../twoLevelRelativePath";
+import component from "@ui/hello";
+import fourLevelRelativePath from "../../../../fourLevelRelativePath";
+import something from "@server/something";
+import xyz from "@ui/xyz";
+import qwerty from "@server/qwerty";
+
+function add(a:number,b:number) {
+  return a + b;
+}

--- a/tests/ImportsSeparatedByEmptyRegex/imports-with-comments.ts
+++ b/tests/ImportsSeparatedByEmptyRegex/imports-with-comments.ts
@@ -1,0 +1,10 @@
+// I am top level comment in this file.
+// I am second line of top level comment in this file.
+import './commands';
+
+// Comment
+// Comment
+
+function add(a:number,b:number) {
+    return a + b;
+}

--- a/tests/ImportsSeparatedByEmptyRegex/imports-with-file-level-comments.ts
+++ b/tests/ImportsSeparatedByEmptyRegex/imports-with-file-level-comments.ts
@@ -1,0 +1,33 @@
+//@ts-ignore
+// I am file top level comments
+import threeLevelRelativePath from "../../../threeLevelRelativePath";
+// I am stick to sameLevelRelativePath
+import sameLevelRelativePath from "./sameLevelRelativePath";
+// I am stick to third party comment
+import thirdParty from "third-party";
+// leading comment
+import { 
+    random // inner comment
+} from './random';
+// leading comment
+export { 
+    random // inner comment
+} from './random';
+import c from 'c';
+import oneLevelRelativePath from "../oneLevelRelativePath";
+import otherthing from "@core/otherthing";
+import a from 'a';
+import twoLevelRelativePath from "../../twoLevelRelativePath";
+import component from "@ui/hello";
+export default {
+    title: 'hello',
+};
+import fourLevelRelativePath from "../../../../fourLevelRelativePath";
+import something from "@server/something";
+import x from 'x';
+
+// I am function comment
+
+function add(a:number,b:number) {
+  return a + b; // I am inside function 
+}

--- a/tests/ImportsSeparatedByEmptyRegex/imports-without-third-party.ts
+++ b/tests/ImportsSeparatedByEmptyRegex/imports-without-third-party.ts
@@ -1,0 +1,8 @@
+// I am top level comment
+import otherthing from "@core/otherthing";
+import abc from "@core/abc";
+// I am comment
+import twoLevelRelativePath from "../../twoLevelRelativePath";
+import component from "@ui/hello";
+import fourLevelRelativePath from "../../../../fourLevelRelativePath";
+import something from "@server/something";

--- a/tests/ImportsSeparatedByEmptyRegex/no-import-export.ts
+++ b/tests/ImportsSeparatedByEmptyRegex/no-import-export.ts
@@ -1,0 +1,3 @@
+function add(a:number,b:number) {
+    return a + b;
+}

--- a/tests/ImportsSeparatedByEmptyRegex/one-import.ts
+++ b/tests/ImportsSeparatedByEmptyRegex/one-import.ts
@@ -1,0 +1,19 @@
+// This example support/index.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands';
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')

--- a/tests/ImportsSeparatedByEmptyRegex/ppsi.spec.js
+++ b/tests/ImportsSeparatedByEmptyRegex/ppsi.spec.js
@@ -1,0 +1,11 @@
+run_spec(__dirname, ['typescript'], {
+    importOrder: [
+        '',
+        '^@core/(.*)$',
+        '^@server/(.*)',
+        '^@ui/(.*)$',
+        '',
+        '^[./]',
+    ],
+    importOrderSeparation: false,
+});


### PR DESCRIPTION
Closes #11

This is an adaptation of https://github.com/trivago/prettier-plugin-sort-imports/pull/42 from @atombrenner.  I wasn't able to use most of the commits from the original branch, because our approach is different in this project, but I did pull in his commit with tests.  

The other change I needed to make here was to modify the cloned nodes in `adjustCommentsOnSortedNodes`, rather than mutating the original, which was leading to some strange bugs in the tests.  