### PR TITLE
Fix: "Ignore unknown option importOrderBuiltinModulesToTop"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,12 @@ const options = {
         default: false,
         description: 'Should specifiers be sorted?',
     },
+    importOrderBuiltinModulesToTop: {
+        type: 'boolean',
+        category: 'Global',
+        default: false,
+        description: 'Should node-builtins be hoisted to the top?',
+    },
 };
 
 module.exports = {


### PR DESCRIPTION
I pulled release 3.4.0 and added the new rule, and unfortunately got these complaints from prettier:

```
[warn] Ignored unknown option { importOrderBuiltinModulesToTop: true }.
```

I compared other Config Options, and this is my guess at the necessary fix