### PR TITLE
Remove node 12 tests, add node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12.x, 14.x, 16.x]
+        node: [14.x, 16.x, 18.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2


### PR DESCRIPTION
Node 12 has reached end of life, and node 18 is the `current` version: https://nodejs.org/en/about/releases/

I don't think this requires a breaking change just yet, but testing with node 12 is causing issues with our tests in https://github.com/IanVS/prettier-plugin-sort-imports/pull/17.