### PR TITLE
Feature: `importOrderMergeDuplicateImports`

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ yarn add --dev @ianvs/prettier-plugin-sort-imports
 
 ## Usage
 
-Add an order in prettier config file.
+Add your preferred settings in your prettier config file.
 
 ```javascript
 module.exports = {
@@ -96,10 +96,16 @@ module.exports = {
   "singleQuote": true,
   "semi": true,
   "importOrder": ["^@core/(.*)$", "^@server/(.*)$", "^@ui/(.*)$", "^[./]"],
+  "importOrderBuiltinModulesToTop": true,
+  "importOrderCaseInsensitive": true,
+  "importOrderParserPlugins": ["typescript", "jsx", "decorators-legacy"],
+  "importOrderMergeDuplicateImports": true,
   "importOrderSeparation": true,
-  "importOrderSortSpecifiers": true
+  "importOrderSortSpecifiers": true,
 }
 ```
+
+_Note: all flags are off by default, so explore your options [below](#apis)_
 
 ### APIs
 
@@ -203,6 +209,14 @@ compared with `"importOrderCaseInsensitive": true`:
 import ExamplesList from './ExamplesList';
 import ExampleView from './ExampleView';
 ```
+
+#### `importOrderMergeDuplicateImports`
+
+**type**: `boolean`
+
+**default value:** `false`
+
+A boolean value to enable or disable multiple import statements referencing the same source. Not all patterns can be merged! Notably: `import type …` will not be converted to `import {type …` or vice-versa.
 
 #### `importOrderParserPlugins`
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ import ExampleView from './ExampleView';
 
 **default value:** `false`
 
-A boolean value to enable or disable multiple import statements referencing the same source. Not all patterns can be merged! Notably: `import type …` will not be converted to `import {type …` or vice-versa.
+When `true`, multiple import statements from the same module will be combined into a single import.
 
 #### `importOrderParserPlugins`
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ yarn add --dev @ianvs/prettier-plugin-sort-imports
 
 Add an order in prettier config file.
 
-```ecmascript 6
+```javascript
 module.exports = {
   "printWidth": 80,
   "tabWidth": 4,

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -7,7 +7,7 @@
 You can define the RegEx in the `importOrder`. For
 example if you want to sort the following imports:
 
-```ecmascript 6
+```javascript
 import React from 'react';
 import classnames from 'classnames';
 import z from '@server/z';
@@ -20,7 +20,7 @@ import q from '@ui/q';
 then the `importOrder` would be `["^@ui/(.*)$","^@server/(.*)$", '^[./]']`.
 Now, the final output would be as follows:
 
-```ecmascript 6
+```javascript
 import classnames from 'classnames';
 import React from 'react';
 import p from '@ui/p';
@@ -35,7 +35,7 @@ import s from './';
 You can define the `<THIRD_PARTY_MODULES>` special word in the `importOrder`. For example above, the `importOrder` would be like `["^@ui/(.*)$", "^@server/(.*)$", "<THIRD_PARTY_MODULES>", '^[./]']`.
 Now, the final output would be as follows:
 
-```ecmascript 6
+```javascript
 import p from '@ui/p';
 import q from '@ui/q';
 import a from '@server/a';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,6 +11,17 @@ export const newLineCharacters = '\n\n';
 export const chunkTypeUnsortable = 'unsortable';
 export const chunkTypeOther = 'other';
 
+/** import Thing from ... or import {Thing} from ... */
+export const importFlavorRegular = 'regular';
+/** import type {} from ...  */
+export const importFlavorType = 'type';
+export const importFlavorSideEffect = 'side-effect';
+export const importFlavorIgnore = 'prettier-ignore';
+export const mergeableImportFlavors = [
+    importFlavorRegular,
+    importFlavorType,
+] as const;
+
 /*
  * Used to mark the position between RegExps,
  * where the not matched imports should be placed

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,14 +11,14 @@ export const newLineCharacters = '\n\n';
 export const chunkTypeUnsortable = 'unsortable';
 export const chunkTypeOther = 'other';
 
-/** import Thing from ... or import {Thing} from ... */
-export const importFlavorRegular = 'regular';
+/** Value imports (including top-level default imports) - import {Thing} from ... or import Thing from ... */
+export const importFlavorValue = 'value';
 /** import type {} from ...  */
 export const importFlavorType = 'type';
 export const importFlavorSideEffect = 'side-effect';
 export const importFlavorIgnore = 'prettier-ignore';
 export const mergeableImportFlavors = [
-    importFlavorRegular,
+    importFlavorValue,
     importFlavorType,
 ] as const;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,12 @@ const options: Record<
         default: false,
         description: 'Should node-builtins be hoisted to the top?',
     },
+    importOrderMergeDuplicateImports: {
+        type: 'boolean',
+        category: 'Global',
+        default: false,
+        description: 'Should duplicate imports be merged?',
+    },
 };
 
 module.exports = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,24 @@
+import type { RequiredOptions as PrettierRequiredOptions } from 'prettier';
 import { parsers as babelParsers } from 'prettier/parser-babel';
 import { parsers as flowParsers } from 'prettier/parser-flow';
 import { parsers as typescriptParsers } from 'prettier/parser-typescript';
 
 import { preprocessor } from './preprocessor';
+import type { PrettierOptions } from './types';
 
-const options = {
+// Not sure what the type from Prettier should be, but this is a good enough start.
+interface PrettierOptionSchema {
+    type: string;
+    category: 'Global';
+    array?: boolean;
+    default: unknown;
+    description: string;
+}
+
+const options: Record<
+    Exclude<keyof PrettierOptions, keyof PrettierRequiredOptions>,
+    PrettierOptionSchema
+> = {
     importOrder: {
         type: 'path',
         category: 'Global',

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -11,11 +11,11 @@ export function preprocessor(code: string, options: PrettierOptions): string {
     const {
         importOrderParserPlugins,
         importOrder,
-        importOrderCaseInsensitive,
-        importOrderSeparation,
-        importOrderGroupNamespaceSpecifiers,
-        importOrderSortSpecifiers,
         importOrderBuiltinModulesToTop,
+        importOrderCaseInsensitive,
+        importOrderGroupNamespaceSpecifiers,
+        importOrderSeparation,
+        importOrderSortSpecifiers,
     } = options;
 
     const importNodes: ImportDeclaration[] = [];
@@ -40,19 +40,25 @@ export function preprocessor(code: string, options: PrettierOptions): string {
         },
     });
 
-    // short-circuit if there are no import declaration
+    // short-circuit if there are no import declarations
     if (importNodes.length === 0) {
         return code;
     }
 
-    const allImports = getSortedNodes(importNodes, {
+    const remainingImports = getSortedNodes(importNodes, {
         importOrder,
-        importOrderCaseInsensitive,
-        importOrderSeparation,
-        importOrderGroupNamespaceSpecifiers,
-        importOrderSortSpecifiers,
         importOrderBuiltinModulesToTop,
+        importOrderCaseInsensitive,
+        importOrderGroupNamespaceSpecifiers,
+        importOrderSeparation,
+        importOrderSortSpecifiers,
     });
 
-    return getCodeFromAst(allImports, code, directives, interpreter);
+    return getCodeFromAst({
+        nodes: remainingImports,
+        importNodes,
+        originalCode: code,
+        directives,
+        interpreter,
+    });
 }

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -19,7 +19,7 @@ export function preprocessor(code: string, options: PrettierOptions): string {
         importOrderSortSpecifiers,
     } = options;
 
-    const importNodes: ImportDeclaration[] = [];
+    const allOriginalImportNodes: ImportDeclaration[] = [];
     const parserOptions: ParserOptions = {
         sourceType: 'module',
         plugins: getExperimentalParserPlugins(importOrderParserPlugins),
@@ -36,17 +36,17 @@ export function preprocessor(code: string, options: PrettierOptions): string {
                 isTSModuleDeclaration(p),
             );
             if (!tsModuleParent) {
-                importNodes.push(path.node);
+                allOriginalImportNodes.push(path.node);
             }
         },
     });
 
     // short-circuit if there are no import declarations
-    if (importNodes.length === 0) {
+    if (allOriginalImportNodes.length === 0) {
         return code;
     }
 
-    const remainingImports = getSortedNodes(importNodes, {
+    const nodesToOutput = getSortedNodes(allOriginalImportNodes, {
         importOrder,
         importOrderBuiltinModulesToTop,
         importOrderCaseInsensitive,
@@ -57,8 +57,8 @@ export function preprocessor(code: string, options: PrettierOptions): string {
     });
 
     return getCodeFromAst({
-        nodes: remainingImports,
-        importNodes,
+        nodesToOutput,
+        allOriginalImportNodes,
         originalCode: code,
         directives,
         interpreter,

--- a/src/preprocessor.ts
+++ b/src/preprocessor.ts
@@ -14,6 +14,7 @@ export function preprocessor(code: string, options: PrettierOptions): string {
         importOrderBuiltinModulesToTop,
         importOrderCaseInsensitive,
         importOrderGroupNamespaceSpecifiers,
+        importOrderMergeDuplicateImports,
         importOrderSeparation,
         importOrderSortSpecifiers,
     } = options;
@@ -50,6 +51,7 @@ export function preprocessor(code: string, options: PrettierOptions): string {
         importOrderBuiltinModulesToTop,
         importOrderCaseInsensitive,
         importOrderGroupNamespaceSpecifiers,
+        importOrderMergeDuplicateImports,
         importOrderSeparation,
         importOrderSortSpecifiers,
     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export interface PrettierOptions extends RequiredOptions {
     importOrderCaseInsensitive: boolean;
     importOrderBuiltinModulesToTop: boolean;
     importOrderGroupNamespaceSpecifiers: boolean;
+    importOrderMergeDuplicateImports: boolean;
     importOrderSeparation: boolean;
     importOrderSortSpecifiers: boolean;
     // should be of type ParserPlugin from '@babel/parser' but prettier does not support nested arrays in options
@@ -28,9 +29,16 @@ export type GetSortedNodes = (
         | 'importOrderBuiltinModulesToTop'
         | 'importOrderCaseInsensitive'
         | 'importOrderGroupNamespaceSpecifiers'
+        | 'importOrderMergeDuplicateImports'
         | 'importOrderSeparation'
         | 'importOrderSortSpecifiers'
     >,
 ) => ImportOrLine[];
 
 export type GetChunkTypeOfNode = (node: ImportDeclaration) => string;
+
+export type GetImportFlavorOfNode = (node: ImportDeclaration) => string;
+
+export type MergeNodesWithMatchingImportFlavors = (
+    nodes: ImportDeclaration[],
+) => ImportDeclaration[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,15 @@
 import { ExpressionStatement, ImportDeclaration } from '@babel/types';
 import { RequiredOptions } from 'prettier';
 
+import {
+    chunkTypeOther,
+    chunkTypeUnsortable,
+    importFlavorIgnore,
+    importFlavorSideEffect,
+    importFlavorType,
+    importFlavorValue,
+} from './constants';
+
 export interface PrettierOptions extends RequiredOptions {
     importOrder: string[];
     importOrderCaseInsensitive: boolean;
@@ -13,9 +22,16 @@ export interface PrettierOptions extends RequiredOptions {
     importOrderParserPlugins: string[];
 }
 
+export type ChunkType = typeof chunkTypeOther | typeof chunkTypeUnsortable;
+export type FlavorType =
+    | typeof importFlavorIgnore
+    | typeof importFlavorSideEffect
+    | typeof importFlavorType
+    | typeof importFlavorValue;
+
 export interface ImportChunk {
     nodes: ImportDeclaration[];
-    type: string;
+    type: ChunkType;
 }
 
 export type ImportGroups = Record<string, ImportDeclaration[]>;
@@ -35,9 +51,9 @@ export type GetSortedNodes = (
     >,
 ) => ImportOrLine[];
 
-export type GetChunkTypeOfNode = (node: ImportDeclaration) => string;
+export type GetChunkTypeOfNode = (node: ImportDeclaration) => ChunkType;
 
-export type GetImportFlavorOfNode = (node: ImportDeclaration) => string;
+export type GetImportFlavorOfNode = (node: ImportDeclaration) => FlavorType;
 
 export type MergeNodesWithMatchingImportFlavors = (
     nodes: ImportDeclaration[],

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,11 +5,11 @@ export interface PrettierOptions extends RequiredOptions {
     importOrder: string[];
     importOrderCaseInsensitive: boolean;
     importOrderBuiltinModulesToTop: boolean;
+    importOrderGroupNamespaceSpecifiers: boolean;
+    importOrderSeparation: boolean;
+    importOrderSortSpecifiers: boolean;
     // should be of type ParserPlugin from '@babel/parser' but prettier does not support nested arrays in options
     importOrderParserPlugins: string[];
-    importOrderSeparation: boolean;
-    importOrderGroupNamespaceSpecifiers: boolean;
-    importOrderSortSpecifiers: boolean;
 }
 
 export interface ImportChunk {
@@ -27,8 +27,8 @@ export type GetSortedNodes = (
         | 'importOrder'
         | 'importOrderBuiltinModulesToTop'
         | 'importOrderCaseInsensitive'
-        | 'importOrderSeparation'
         | 'importOrderGroupNamespaceSpecifiers'
+        | 'importOrderSeparation'
         | 'importOrderSortSpecifiers'
     >,
 ) => ImportOrLine[];

--- a/src/utils/__tests__/get-all-comments-from-nodes.spec.ts
+++ b/src/utils/__tests__/get-all-comments-from-nodes.spec.ts
@@ -10,11 +10,11 @@ const getSortedImportNodes = (code: string, options?: ParserOptions) => {
 
     return getSortedNodes(importNodes, {
         importOrder: [],
-        importOrderCaseInsensitive: false,
-        importOrderSeparation: false,
-        importOrderGroupNamespaceSpecifiers: false,
-        importOrderSortSpecifiers: false,
         importOrderBuiltinModulesToTop: false,
+        importOrderCaseInsensitive: false,
+        importOrderGroupNamespaceSpecifiers: false,
+        importOrderSeparation: false,
+        importOrderSortSpecifiers: false,
     });
 };
 

--- a/src/utils/__tests__/get-all-comments-from-nodes.spec.ts
+++ b/src/utils/__tests__/get-all-comments-from-nodes.spec.ts
@@ -13,6 +13,7 @@ const getSortedImportNodes = (code: string, options?: ParserOptions) => {
         importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: false,
         importOrderGroupNamespaceSpecifiers: false,
+        importOrderMergeDuplicateImports: false,
         importOrderSeparation: false,
         importOrderSortSpecifiers: false,
     });

--- a/src/utils/__tests__/get-code-from-ast.spec.ts
+++ b/src/utils/__tests__/get-code-from-ast.spec.ts
@@ -47,13 +47,16 @@ it('merges duplicate imports correctly', () => {
 // second comment
 import z from 'z';
 import c from 'c';
+import type {C} from 'c';
+import type {See} from 'c';
 import g from 'g';
 import t from 't';
 import k from 'k';
 import a from 'a';
 import {b} from 'a';
+import {type Bee} from 'a';
 `;
-    const importNodes = getImportNodes(code);
+    const importNodes = getImportNodes(code, { plugins: ['typescript'] });
     const sortedNodes = getSortedNodes(importNodes, {
         importOrder: [],
         importOrderBuiltinModulesToTop: false,
@@ -72,8 +75,9 @@ import {b} from 'a';
     expect(format(formatted, { parser: 'babel' })).toEqual(
         `// first comment
 // second comment
-import a, { b } from "a";
+import a, { b, type Bee } from "a";
 import c from "c";
+import type { C, See } from "c";
 import g from "g";
 import k from "k";
 import t from "t";

--- a/src/utils/__tests__/get-code-from-ast.spec.ts
+++ b/src/utils/__tests__/get-code-from-ast.spec.ts
@@ -25,7 +25,7 @@ import a from 'a';
         importOrderSortSpecifiers: false,
     });
     const formatted = getCodeFromAst({
-        nodes: sortedNodes,
+        nodesToOutput: sortedNodes,
         originalCode: code,
         directives: [],
     });
@@ -64,8 +64,8 @@ import {b} from 'a';
         importOrderSortSpecifiers: false,
     });
     const formatted = getCodeFromAst({
-        nodes: sortedNodes,
-        importNodes,
+        nodesToOutput: sortedNodes,
+        allOriginalImportNodes: importNodes,
         originalCode: code,
         directives: [],
     });

--- a/src/utils/__tests__/get-code-from-ast.spec.ts
+++ b/src/utils/__tests__/get-code-from-ast.spec.ts
@@ -4,7 +4,7 @@ import { getCodeFromAst } from '../get-code-from-ast';
 import { getImportNodes } from '../get-import-nodes';
 import { getSortedNodes } from '../get-sorted-nodes';
 
-test('it sorts imports correctly', () => {
+it('sorts imports correctly', () => {
     const code = `// first comment
 // second comment
 import z from 'z';
@@ -17,13 +17,17 @@ import a from 'a';
     const importNodes = getImportNodes(code);
     const sortedNodes = getSortedNodes(importNodes, {
         importOrder: [],
-        importOrderCaseInsensitive: false,
-        importOrderSeparation: false,
-        importOrderGroupNamespaceSpecifiers: false,
-        importOrderSortSpecifiers: false,
         importOrderBuiltinModulesToTop: false,
+        importOrderCaseInsensitive: false,
+        importOrderGroupNamespaceSpecifiers: false,
+        importOrderSeparation: false,
+        importOrderSortSpecifiers: false,
     });
-    const formatted = getCodeFromAst(sortedNodes, code, [], undefined);
+    const formatted = getCodeFromAst({
+        nodes: sortedNodes,
+        originalCode: code,
+        directives: [],
+    });
     expect(format(formatted, { parser: 'babel' })).toEqual(
         `// first comment
 // second comment

--- a/src/utils/__tests__/get-code-from-ast.spec.ts
+++ b/src/utils/__tests__/get-code-from-ast.spec.ts
@@ -20,6 +20,7 @@ import a from 'a';
         importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: false,
         importOrderGroupNamespaceSpecifiers: false,
+        importOrderMergeDuplicateImports: false,
         importOrderSeparation: false,
         importOrderSortSpecifiers: false,
     });
@@ -32,6 +33,46 @@ import a from 'a';
         `// first comment
 // second comment
 import a from "a";
+import c from "c";
+import g from "g";
+import k from "k";
+import t from "t";
+import z from "z";
+`,
+    );
+});
+
+it('merges duplicate imports correctly', () => {
+    const code = `// first comment
+// second comment
+import z from 'z';
+import c from 'c';
+import g from 'g';
+import t from 't';
+import k from 'k';
+import a from 'a';
+import {b} from 'a';
+`;
+    const importNodes = getImportNodes(code);
+    const sortedNodes = getSortedNodes(importNodes, {
+        importOrder: [],
+        importOrderBuiltinModulesToTop: false,
+        importOrderCaseInsensitive: false,
+        importOrderGroupNamespaceSpecifiers: false,
+        importOrderMergeDuplicateImports: true,
+        importOrderSeparation: false,
+        importOrderSortSpecifiers: false,
+    });
+    const formatted = getCodeFromAst({
+        nodes: sortedNodes,
+        importNodes,
+        originalCode: code,
+        directives: [],
+    });
+    expect(format(formatted, { parser: 'babel' })).toEqual(
+        `// first comment
+// second comment
+import a, { b } from "a";
 import c from "c";
 import g from "g";
 import k from "k";

--- a/src/utils/__tests__/get-import-flavor-of-node.spec.ts
+++ b/src/utils/__tests__/get-import-flavor-of-node.spec.ts
@@ -1,0 +1,32 @@
+import { getImportFlavorOfNode } from '../get-import-flavor-of-node';
+import { getImportNodes } from '../get-import-nodes';
+
+it('should correctly classify a bunch of import expressions', () => {
+    expect(
+        getImportNodes(
+            `
+import "./side-effects";
+import { a } from "a";
+import type { b } from "b";
+import { type C } from "c";
+import D from "d";
+
+import e = require("e"); // Doesn't count as import
+const f = require("f"); // Doesn't count as import
+
+// prettier-ignore
+import { g } from "g";
+`,
+            { plugins: ['typescript'] },
+        ).map((node) => getImportFlavorOfNode(node)),
+    ).toMatchInlineSnapshot(`
+        Array [
+          "side-effect",
+          "regular",
+          "type",
+          "regular",
+          "regular",
+          "prettier-ignore",
+        ]
+    `);
+});

--- a/src/utils/__tests__/get-import-flavor-of-node.spec.ts
+++ b/src/utils/__tests__/get-import-flavor-of-node.spec.ts
@@ -22,10 +22,10 @@ import { g } from "g";
     ).toMatchInlineSnapshot(`
         Array [
           "side-effect",
-          "regular",
+          "value",
           "type",
-          "regular",
-          "regular",
+          "value",
+          "value",
           "prettier-ignore",
         ]
     `);

--- a/src/utils/__tests__/get-sorted-nodes-by-import-order.spec.ts
+++ b/src/utils/__tests__/get-sorted-nodes-by-import-order.spec.ts
@@ -28,11 +28,11 @@ test('it returns all sorted nodes', () => {
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^[./]'],
-        importOrderCaseInsensitive: false,
-        importOrderSeparation: false,
-        importOrderGroupNamespaceSpecifiers: false,
-        importOrderSortSpecifiers: false,
         importOrderBuiltinModulesToTop: false,
+        importOrderCaseInsensitive: false,
+        importOrderGroupNamespaceSpecifiers: false,
+        importOrderSeparation: false,
+        importOrderSortSpecifiers: false,
     }) as ImportDeclaration[];
 
     expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
@@ -81,11 +81,11 @@ test('it returns all sorted nodes case-insensitive', () => {
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^[./]'],
-        importOrderCaseInsensitive: true,
-        importOrderSeparation: false,
-        importOrderGroupNamespaceSpecifiers: false,
-        importOrderSortSpecifiers: false,
         importOrderBuiltinModulesToTop: false,
+        importOrderCaseInsensitive: true,
+        importOrderGroupNamespaceSpecifiers: false,
+        importOrderSeparation: false,
+        importOrderSortSpecifiers: false,
     }) as ImportDeclaration[];
 
     expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
@@ -134,11 +134,11 @@ test('it returns all sorted nodes with sort order', () => {
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^a$', '^t$', '^k$', '^B', '^[./]'],
-        importOrderCaseInsensitive: false,
-        importOrderSeparation: false,
-        importOrderGroupNamespaceSpecifiers: false,
-        importOrderSortSpecifiers: false,
         importOrderBuiltinModulesToTop: false,
+        importOrderCaseInsensitive: false,
+        importOrderGroupNamespaceSpecifiers: false,
+        importOrderSeparation: false,
+        importOrderSortSpecifiers: false,
     }) as ImportDeclaration[];
 
     expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
@@ -187,11 +187,11 @@ test('it returns all sorted nodes with sort order case-insensitive', () => {
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^a$', '^t$', '^k$', '^B', '^[./]'],
-        importOrderCaseInsensitive: true,
-        importOrderSeparation: false,
-        importOrderGroupNamespaceSpecifiers: false,
-        importOrderSortSpecifiers: false,
         importOrderBuiltinModulesToTop: false,
+        importOrderCaseInsensitive: true,
+        importOrderGroupNamespaceSpecifiers: false,
+        importOrderSeparation: false,
+        importOrderSortSpecifiers: false,
     }) as ImportDeclaration[];
     expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
         'c',
@@ -239,11 +239,11 @@ test('it returns all sorted import nodes with sorted import specifiers', () => {
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^a$', '^t$', '^k$', '^B', '^[./]'],
-        importOrderCaseInsensitive: false,
-        importOrderSeparation: false,
-        importOrderGroupNamespaceSpecifiers: false,
-        importOrderSortSpecifiers: true,
         importOrderBuiltinModulesToTop: false,
+        importOrderCaseInsensitive: false,
+        importOrderGroupNamespaceSpecifiers: false,
+        importOrderSeparation: false,
+        importOrderSortSpecifiers: true,
     }) as ImportDeclaration[];
     expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
         'XY',
@@ -291,11 +291,11 @@ test('it returns all sorted import nodes with sorted import specifiers with case
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^a$', '^t$', '^k$', '^B', '^[./]'],
-        importOrderCaseInsensitive: true,
-        importOrderSeparation: false,
-        importOrderGroupNamespaceSpecifiers: false,
-        importOrderSortSpecifiers: true,
         importOrderBuiltinModulesToTop: false,
+        importOrderCaseInsensitive: true,
+        importOrderGroupNamespaceSpecifiers: false,
+        importOrderSeparation: false,
+        importOrderSortSpecifiers: true,
     }) as ImportDeclaration[];
     expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
         'c',
@@ -343,11 +343,11 @@ test('it returns all sorted nodes with custom third party modules', () => {
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^a$', '<THIRD_PARTY_MODULES>', '^t$', '^k$', '^[./]'],
-        importOrderSeparation: false,
+        importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: true,
         importOrderGroupNamespaceSpecifiers: false,
+        importOrderSeparation: false,
         importOrderSortSpecifiers: false,
-        importOrderBuiltinModulesToTop: false,
     }) as ImportDeclaration[];
     expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
         'a',
@@ -372,11 +372,11 @@ test('it returns all sorted nodes with namespace specifiers at the top', () => {
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^[./]'],
-        importOrderCaseInsensitive: false,
-        importOrderSeparation: false,
-        importOrderGroupNamespaceSpecifiers: true,
-        importOrderSortSpecifiers: false,
         importOrderBuiltinModulesToTop: false,
+        importOrderCaseInsensitive: false,
+        importOrderGroupNamespaceSpecifiers: true,
+        importOrderSeparation: false,
+        importOrderSortSpecifiers: false,
     }) as ImportDeclaration[];
 
     expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
@@ -402,11 +402,11 @@ test('it returns all sorted nodes with builtin specifiers at the top, ', () => {
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^[./]'],
-        importOrderCaseInsensitive: false,
-        importOrderSeparation: false,
-        importOrderGroupNamespaceSpecifiers: false,
-        importOrderSortSpecifiers: false,
         importOrderBuiltinModulesToTop: true,
+        importOrderCaseInsensitive: false,
+        importOrderGroupNamespaceSpecifiers: false,
+        importOrderSeparation: false,
+        importOrderSortSpecifiers: false,
     }) as ImportDeclaration[];
 
     expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
@@ -432,11 +432,11 @@ test('it returns all sorted nodes with custom third party modules and builtins a
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^a$', '<THIRD_PARTY_MODULES>', '^t$', '^k$', '^[./]'],
-        importOrderSeparation: false,
+        importOrderBuiltinModulesToTop: true,
         importOrderCaseInsensitive: true,
         importOrderGroupNamespaceSpecifiers: false,
+        importOrderSeparation: false,
         importOrderSortSpecifiers: false,
-        importOrderBuiltinModulesToTop: true,
     }) as ImportDeclaration[];
     expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
         'node:fs/promises',
@@ -461,11 +461,11 @@ test('it adds newlines when importOrderSeparation is true', () => {
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^[./]'],
-        importOrderSeparation: true,
+        importOrderBuiltinModulesToTop: true,
         importOrderCaseInsensitive: true,
         importOrderGroupNamespaceSpecifiers: false,
+        importOrderSeparation: true,
         importOrderSortSpecifiers: false,
-        importOrderBuiltinModulesToTop: true,
     }) as ImportDeclaration[];
     expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
         'node:fs/promises',
@@ -500,11 +500,11 @@ test('it returns all sorted nodes with custom separation', () => {
             '^k$',
             '^[./]',
         ],
-        importOrderSeparation: false,
+        importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: true,
         importOrderGroupNamespaceSpecifiers: false,
+        importOrderSeparation: false,
         importOrderSortSpecifiers: false,
-        importOrderBuiltinModulesToTop: false,
     }) as ImportDeclaration[];
     expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
         'a',
@@ -537,11 +537,11 @@ test('it allows both importOrderSeparation and custom separation (but why?)', ()
             '^k$',
             '^[./]',
         ],
-        importOrderSeparation: true,
+        importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: true,
         importOrderGroupNamespaceSpecifiers: false,
+        importOrderSeparation: true,
         importOrderSortSpecifiers: false,
-        importOrderBuiltinModulesToTop: false,
     }) as ImportDeclaration[];
     expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
         'a',
@@ -580,11 +580,11 @@ test('it does not add multiple custom import separators', () => {
             '^k$',
             '^[./]',
         ],
-        importOrderSeparation: false,
+        importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: true,
         importOrderGroupNamespaceSpecifiers: false,
+        importOrderSeparation: false,
         importOrderSortSpecifiers: false,
-        importOrderBuiltinModulesToTop: false,
     }) as ImportDeclaration[];
     expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
         'a',

--- a/src/utils/__tests__/get-sorted-nodes-by-import-order.spec.ts
+++ b/src/utils/__tests__/get-sorted-nodes-by-import-order.spec.ts
@@ -31,6 +31,7 @@ test('it returns all sorted nodes', () => {
         importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: false,
         importOrderGroupNamespaceSpecifiers: false,
+        importOrderMergeDuplicateImports: false,
         importOrderSeparation: false,
         importOrderSortSpecifiers: false,
     }) as ImportDeclaration[];
@@ -84,6 +85,7 @@ test('it returns all sorted nodes case-insensitive', () => {
         importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: true,
         importOrderGroupNamespaceSpecifiers: false,
+        importOrderMergeDuplicateImports: false,
         importOrderSeparation: false,
         importOrderSortSpecifiers: false,
     }) as ImportDeclaration[];
@@ -137,6 +139,7 @@ test('it returns all sorted nodes with sort order', () => {
         importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: false,
         importOrderGroupNamespaceSpecifiers: false,
+        importOrderMergeDuplicateImports: false,
         importOrderSeparation: false,
         importOrderSortSpecifiers: false,
     }) as ImportDeclaration[];
@@ -190,6 +193,7 @@ test('it returns all sorted nodes with sort order case-insensitive', () => {
         importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: true,
         importOrderGroupNamespaceSpecifiers: false,
+        importOrderMergeDuplicateImports: false,
         importOrderSeparation: false,
         importOrderSortSpecifiers: false,
     }) as ImportDeclaration[];
@@ -242,6 +246,7 @@ test('it returns all sorted import nodes with sorted import specifiers', () => {
         importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: false,
         importOrderGroupNamespaceSpecifiers: false,
+        importOrderMergeDuplicateImports: false,
         importOrderSeparation: false,
         importOrderSortSpecifiers: true,
     }) as ImportDeclaration[];
@@ -294,6 +299,7 @@ test('it returns all sorted import nodes with sorted import specifiers with case
         importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: true,
         importOrderGroupNamespaceSpecifiers: false,
+        importOrderMergeDuplicateImports: false,
         importOrderSeparation: false,
         importOrderSortSpecifiers: true,
     }) as ImportDeclaration[];
@@ -346,6 +352,7 @@ test('it returns all sorted nodes with custom third party modules', () => {
         importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: true,
         importOrderGroupNamespaceSpecifiers: false,
+        importOrderMergeDuplicateImports: false,
         importOrderSeparation: false,
         importOrderSortSpecifiers: false,
     }) as ImportDeclaration[];
@@ -375,6 +382,7 @@ test('it returns all sorted nodes with namespace specifiers at the top', () => {
         importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: false,
         importOrderGroupNamespaceSpecifiers: true,
+        importOrderMergeDuplicateImports: false,
         importOrderSeparation: false,
         importOrderSortSpecifiers: false,
     }) as ImportDeclaration[];
@@ -405,6 +413,7 @@ test('it returns all sorted nodes with builtin specifiers at the top, ', () => {
         importOrderBuiltinModulesToTop: true,
         importOrderCaseInsensitive: false,
         importOrderGroupNamespaceSpecifiers: false,
+        importOrderMergeDuplicateImports: false,
         importOrderSeparation: false,
         importOrderSortSpecifiers: false,
     }) as ImportDeclaration[];
@@ -435,6 +444,7 @@ test('it returns all sorted nodes with custom third party modules and builtins a
         importOrderBuiltinModulesToTop: true,
         importOrderCaseInsensitive: true,
         importOrderGroupNamespaceSpecifiers: false,
+        importOrderMergeDuplicateImports: false,
         importOrderSeparation: false,
         importOrderSortSpecifiers: false,
     }) as ImportDeclaration[];
@@ -464,6 +474,7 @@ test('it adds newlines when importOrderSeparation is true', () => {
         importOrderBuiltinModulesToTop: true,
         importOrderCaseInsensitive: true,
         importOrderGroupNamespaceSpecifiers: false,
+        importOrderMergeDuplicateImports: false,
         importOrderSeparation: true,
         importOrderSortSpecifiers: false,
     }) as ImportDeclaration[];
@@ -503,6 +514,7 @@ test('it returns all sorted nodes with custom separation', () => {
         importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: true,
         importOrderGroupNamespaceSpecifiers: false,
+        importOrderMergeDuplicateImports: false,
         importOrderSeparation: false,
         importOrderSortSpecifiers: false,
     }) as ImportDeclaration[];
@@ -540,6 +552,7 @@ test('it allows both importOrderSeparation and custom separation (but why?)', ()
         importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: true,
         importOrderGroupNamespaceSpecifiers: false,
+        importOrderMergeDuplicateImports: false,
         importOrderSeparation: true,
         importOrderSortSpecifiers: false,
     }) as ImportDeclaration[];
@@ -583,6 +596,7 @@ test('it does not add multiple custom import separators', () => {
         importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: true,
         importOrderGroupNamespaceSpecifiers: false,
+        importOrderMergeDuplicateImports: false,
         importOrderSeparation: false,
         importOrderSortSpecifiers: false,
     }) as ImportDeclaration[];

--- a/src/utils/__tests__/get-sorted-nodes.spec.ts
+++ b/src/utils/__tests__/get-sorted-nodes.spec.ts
@@ -29,11 +29,11 @@ test('it returns all sorted nodes, preserving the order side effect nodes', () =
     const result = getImportNodes(code);
     const sorted = getSortedNodes(result, {
         importOrder: [],
-        importOrderCaseInsensitive: false,
-        importOrderSeparation: false,
-        importOrderGroupNamespaceSpecifiers: false,
-        importOrderSortSpecifiers: false,
         importOrderBuiltinModulesToTop: false,
+        importOrderCaseInsensitive: false,
+        importOrderGroupNamespaceSpecifiers: false,
+        importOrderSeparation: false,
+        importOrderSortSpecifiers: false,
     }) as ImportDeclaration[];
 
     expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([

--- a/src/utils/__tests__/get-sorted-nodes.spec.ts
+++ b/src/utils/__tests__/get-sorted-nodes.spec.ts
@@ -32,6 +32,7 @@ test('it returns all sorted nodes, preserving the order side effect nodes', () =
         importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: false,
         importOrderGroupNamespaceSpecifiers: false,
+        importOrderMergeDuplicateImports: false,
         importOrderSeparation: false,
         importOrderSortSpecifiers: false,
     }) as ImportDeclaration[];

--- a/src/utils/__tests__/merge-nodes-with-matching-flavors.spec.ts
+++ b/src/utils/__tests__/merge-nodes-with-matching-flavors.spec.ts
@@ -51,34 +51,33 @@ it('should merge duplicate imports within a given chunk', () => {
         directives: [],
     });
 
-    expect(format(formatted, { parser: 'babel' })).toMatchInlineSnapshot(`
-        "import type { A, B } from \\"a\\";
-        import { Junk } from \\"junk-group-1\\";
+    expect(format(formatted, { parser: 'babel' }))
+        .toEqual(`import type { A, B } from "a";
+import { Junk } from "junk-group-1";
 
-        import \\"./side-effects1\\";
+import "./side-effects1";
 
-        // C, E and D will be separated from A, B because side-effects in-between
-        import type { C, E } from \\"a\\";
-        import { D } from \\"a\\";
+// C, E and D will be separated from A, B because side-effects in-between
+import type { C, E } from "a";
+import { D } from "a";
 
-        // prettier-ignore
-        import type { NoMerge1 } from \\"a\\";
-        // prettier-ignore
-        import { NoMerge2 } from \\"a\\";
+// prettier-ignore
+import type { NoMerge1 } from "a";
+// prettier-ignore
+import { NoMerge2 } from "a";
 
-        import { F } from \\"a\\";
-        // F Will be alone because prettier-ignore in-between
-        import { G, H } from \\"b\\";
-        import * as J from \\"c\\";
-        import * as K from \\"c\\";
-        // * as J, * as K can't merge because both Namespaces
-        import { I } from \\"c\\";
-        import { default as Def1, default as Def2 } from \\"d\\";
-        import Foo1 from \\"e\\";
-        import Foo2 from \\"e\\";
-        import { Junk2 } from \\"junk-group-2\\";
-        "
-    `);
+import { F } from "a";
+// F Will be alone because prettier-ignore in-between
+import { G, H } from "b";
+import * as J from "c";
+import * as K from "c";
+// * as J, * as K can't merge because both Namespaces
+import { I } from "c";
+import { default as Def1, default as Def2 } from "d";
+import Foo1 from "e";
+import Foo2 from "e";
+import { Junk2 } from "junk-group-2";
+`);
 });
 it("doesn't merge duplicate imports if option disabled", () => {
     const code = `
@@ -127,36 +126,35 @@ it("doesn't merge duplicate imports if option disabled", () => {
         directives: [],
     });
 
-    expect(format(formatted, { parser: 'babel' })).toMatchInlineSnapshot(`
-        "import type { A } from \\"a\\";
-        import type { B } from \\"a\\";
-        import { Junk } from \\"junk-group-1\\";
+    expect(format(formatted, { parser: 'babel' }))
+        .toEqual(`import type { A } from "a";
+import type { B } from "a";
+import { Junk } from "junk-group-1";
 
-        import \\"./side-effects1\\";
+import "./side-effects1";
 
-        // C, E and D will be separated from A, B because side-effects in-between
-        import type { C } from \\"a\\";
-        import { D } from \\"a\\";
-        import type { E } from \\"a\\";
+// C, E and D will be separated from A, B because side-effects in-between
+import type { C } from "a";
+import { D } from "a";
+import type { E } from "a";
 
-        // prettier-ignore
-        import type { NoMerge1 } from \\"a\\";
-        // prettier-ignore
-        import { NoMerge2 } from \\"a\\";
+// prettier-ignore
+import type { NoMerge1 } from "a";
+// prettier-ignore
+import { NoMerge2 } from "a";
 
-        import { F } from \\"a\\";
-        import { H } from \\"b\\";
-        // F Will be alone because prettier-ignore in-between
-        import { G } from \\"b\\";
-        import * as J from \\"c\\";
-        import * as K from \\"c\\";
-        // * as J, * as K can't merge because both Namespaces
-        import { I } from \\"c\\";
-        import { default as Def2 } from \\"d\\";
-        import { default as Def1 } from \\"d\\";
-        import Foo1 from \\"e\\";
-        import Foo2 from \\"e\\";
-        import { Junk2 } from \\"junk-group-2\\";
-        "
-    `);
+import { F } from "a";
+import { H } from "b";
+// F Will be alone because prettier-ignore in-between
+import { G } from "b";
+import * as J from "c";
+import * as K from "c";
+// * as J, * as K can't merge because both Namespaces
+import { I } from "c";
+import { default as Def2 } from "d";
+import { default as Def1 } from "d";
+import Foo1 from "e";
+import Foo2 from "e";
+import { Junk2 } from "junk-group-2";
+`);
 });

--- a/src/utils/__tests__/merge-nodes-with-matching-flavors.spec.ts
+++ b/src/utils/__tests__/merge-nodes-with-matching-flavors.spec.ts
@@ -162,3 +162,36 @@ import Foo2 from "e";
 import { Junk2 } from "junk-group-2";
 `);
 });
+
+it('merges named and default imports correctly', () => {
+    const code = `
+    import A, { a } from "a";
+    import { ahh } from "a";
+    import { bee } from "b";
+    import B from "b";
+    `;
+    const allOriginalImportNodes = getImportNodes(code, {
+        plugins: ['typescript'],
+    });
+
+    const nodesToOutput = getSortedNodes(allOriginalImportNodes, {
+        importOrder: [],
+        importOrderBuiltinModulesToTop: false,
+        importOrderCaseInsensitive: false,
+        importOrderGroupNamespaceSpecifiers: false,
+        importOrderMergeDuplicateImports: true,
+        importOrderSeparation: true,
+        importOrderSortSpecifiers: true,
+    });
+    const formatted = getCodeFromAst({
+        nodesToOutput,
+        allOriginalImportNodes,
+        originalCode: code,
+        directives: [],
+    });
+
+    expect(format(formatted, { parser: 'babel' }))
+        .toEqual(`import A, { a, ahh } from "a";
+import B, { bee } from "b";
+`);
+});

--- a/src/utils/__tests__/merge-nodes-with-matching-flavors.spec.ts
+++ b/src/utils/__tests__/merge-nodes-with-matching-flavors.spec.ts
@@ -1,0 +1,162 @@
+import { format } from 'prettier';
+
+import { getCodeFromAst } from '../get-code-from-ast';
+import { getImportNodes } from '../get-import-nodes';
+import { getSortedNodes } from '../get-sorted-nodes';
+
+it('should merge duplicate imports within a given chunk', () => {
+    const code = `
+    import type { A } from 'a';
+    import { Junk } from 'junk-group-1'
+    import type { B } from 'a';
+    import "./side-effects1";
+    // C, E and D will be separated from A, B because side-effects in-between
+    import type { C } from 'a';
+    import { D } from "a";
+    import type { E } from "a";
+    // prettier-ignore
+    import type { NoMerge1 } from "a";
+    // prettier-ignore
+    import { NoMerge2 } from "a";
+    import { H } from 'b';
+    import { F } from 'a';
+    // F Will be alone because prettier-ignore in-between
+
+    import { G } from 'b';
+    import * as J from 'c';
+    import { Junk2 } from 'junk-group-2'
+    import * as K from "c";
+    // * as J, * as K can't merge because both Namespaces
+    import {I} from "c"
+    import { default as Def2 } from 'd';
+    import { default as Def1 } from 'd';
+    import Foo1 from 'e';
+    import Foo2 from 'e';
+    `;
+    const importNodes = getImportNodes(code, { plugins: ['typescript'] });
+
+    const sortedNodes = getSortedNodes(importNodes, {
+        importOrder: [],
+        importOrderBuiltinModulesToTop: false,
+        importOrderCaseInsensitive: false,
+        importOrderGroupNamespaceSpecifiers: false,
+        importOrderMergeDuplicateImports: true,
+        importOrderSeparation: true,
+        importOrderSortSpecifiers: true,
+    });
+    const formatted = getCodeFromAst({
+        nodes: sortedNodes,
+        importNodes,
+        originalCode: code,
+        directives: [],
+    });
+
+    expect(format(formatted, { parser: 'babel' })).toMatchInlineSnapshot(`
+        "import type { A, B } from \\"a\\";
+        import { Junk } from \\"junk-group-1\\";
+
+        import \\"./side-effects1\\";
+
+        // C, E and D will be separated from A, B because side-effects in-between
+        import type { C, E } from \\"a\\";
+        import { D } from \\"a\\";
+
+        // prettier-ignore
+        import type { NoMerge1 } from \\"a\\";
+        // prettier-ignore
+        import { NoMerge2 } from \\"a\\";
+
+        import { F } from \\"a\\";
+        // F Will be alone because prettier-ignore in-between
+        import { G, H } from \\"b\\";
+        import * as J from \\"c\\";
+        import * as K from \\"c\\";
+        // * as J, * as K can't merge because both Namespaces
+        import { I } from \\"c\\";
+        import { default as Def1, default as Def2 } from \\"d\\";
+        import Foo1 from \\"e\\";
+        import Foo2 from \\"e\\";
+        import { Junk2 } from \\"junk-group-2\\";
+        "
+    `);
+});
+it("doesn't merge duplicate imports if option disabled", () => {
+    const code = `
+    import type { A } from 'a';
+    import { Junk } from 'junk-group-1'
+    import type { B } from 'a';
+    import "./side-effects1";
+    // C, E and D will be separated from A, B because side-effects in-between
+    import type { C } from 'a';
+    import { D } from "a";
+    import type { E } from "a";
+    // prettier-ignore
+    import type { NoMerge1 } from "a";
+    // prettier-ignore
+    import { NoMerge2 } from "a";
+    import { H } from 'b';
+    import { F } from 'a';
+    // F Will be alone because prettier-ignore in-between
+
+    import { G } from 'b';
+    import * as J from 'c';
+    import { Junk2 } from 'junk-group-2'
+    import * as K from "c";
+    // * as J, * as K can't merge because both Namespaces
+    import {I} from "c"
+    import { default as Def2 } from 'd';
+    import { default as Def1 } from 'd';
+    import Foo1 from 'e';
+    import Foo2 from 'e';
+    `;
+    const importNodes = getImportNodes(code, { plugins: ['typescript'] });
+
+    const sortedNodes = getSortedNodes(importNodes, {
+        importOrder: [],
+        importOrderBuiltinModulesToTop: false,
+        importOrderCaseInsensitive: false,
+        importOrderGroupNamespaceSpecifiers: false,
+        importOrderMergeDuplicateImports: false,
+        importOrderSeparation: true,
+        importOrderSortSpecifiers: true,
+    });
+    const formatted = getCodeFromAst({
+        nodes: sortedNodes,
+        importNodes,
+        originalCode: code,
+        directives: [],
+    });
+
+    expect(format(formatted, { parser: 'babel' })).toMatchInlineSnapshot(`
+        "import type { A } from \\"a\\";
+        import type { B } from \\"a\\";
+        import { Junk } from \\"junk-group-1\\";
+
+        import \\"./side-effects1\\";
+
+        // C, E and D will be separated from A, B because side-effects in-between
+        import type { C } from \\"a\\";
+        import { D } from \\"a\\";
+        import type { E } from \\"a\\";
+
+        // prettier-ignore
+        import type { NoMerge1 } from \\"a\\";
+        // prettier-ignore
+        import { NoMerge2 } from \\"a\\";
+
+        import { F } from \\"a\\";
+        import { H } from \\"b\\";
+        // F Will be alone because prettier-ignore in-between
+        import { G } from \\"b\\";
+        import * as J from \\"c\\";
+        import * as K from \\"c\\";
+        // * as J, * as K can't merge because both Namespaces
+        import { I } from \\"c\\";
+        import { default as Def2 } from \\"d\\";
+        import { default as Def1 } from \\"d\\";
+        import Foo1 from \\"e\\";
+        import Foo2 from \\"e\\";
+        import { Junk2 } from \\"junk-group-2\\";
+        "
+    `);
+});

--- a/src/utils/__tests__/merge-nodes-with-matching-flavors.spec.ts
+++ b/src/utils/__tests__/merge-nodes-with-matching-flavors.spec.ts
@@ -33,9 +33,11 @@ it('should merge duplicate imports within a given chunk', () => {
     import Foo1 from 'e';
     import Foo2 from 'e';
     `;
-    const importNodes = getImportNodes(code, { plugins: ['typescript'] });
+    const allOriginalImportNodes = getImportNodes(code, {
+        plugins: ['typescript'],
+    });
 
-    const sortedNodes = getSortedNodes(importNodes, {
+    const nodesToOutput = getSortedNodes(allOriginalImportNodes, {
         importOrder: [],
         importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: false,
@@ -45,8 +47,8 @@ it('should merge duplicate imports within a given chunk', () => {
         importOrderSortSpecifiers: true,
     });
     const formatted = getCodeFromAst({
-        nodes: sortedNodes,
-        importNodes,
+        nodesToOutput,
+        allOriginalImportNodes,
         originalCode: code,
         directives: [],
     });
@@ -108,9 +110,11 @@ it("doesn't merge duplicate imports if option disabled", () => {
     import Foo1 from 'e';
     import Foo2 from 'e';
     `;
-    const importNodes = getImportNodes(code, { plugins: ['typescript'] });
+    const allOriginalImportNodes = getImportNodes(code, {
+        plugins: ['typescript'],
+    });
 
-    const sortedNodes = getSortedNodes(importNodes, {
+    const nodesToOutput = getSortedNodes(allOriginalImportNodes, {
         importOrder: [],
         importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: false,
@@ -120,8 +124,8 @@ it("doesn't merge duplicate imports if option disabled", () => {
         importOrderSortSpecifiers: true,
     });
     const formatted = getCodeFromAst({
-        nodes: sortedNodes,
-        importNodes,
+        nodesToOutput,
+        allOriginalImportNodes,
         originalCode: code,
         directives: [],
     });

--- a/src/utils/__tests__/remove-nodes-from-original-code.spec.ts
+++ b/src/utils/__tests__/remove-nodes-from-original-code.spec.ts
@@ -26,6 +26,7 @@ test('it should remove nodes from the original code', () => {
         importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: false,
         importOrderGroupNamespaceSpecifiers: false,
+        importOrderMergeDuplicateImports: false,
         importOrderSeparation: false,
         importOrderSortSpecifiers: false,
     });

--- a/src/utils/__tests__/remove-nodes-from-original-code.spec.ts
+++ b/src/utils/__tests__/remove-nodes-from-original-code.spec.ts
@@ -23,11 +23,11 @@ test('it should remove nodes from the original code', () => {
     const importNodes = getImportNodes(code);
     const sortedNodes = getSortedNodes(importNodes, {
         importOrder: [],
-        importOrderCaseInsensitive: false,
-        importOrderSeparation: false,
-        importOrderGroupNamespaceSpecifiers: false,
-        importOrderSortSpecifiers: false,
         importOrderBuiltinModulesToTop: false,
+        importOrderCaseInsensitive: false,
+        importOrderGroupNamespaceSpecifiers: false,
+        importOrderSeparation: false,
+        importOrderSortSpecifiers: false,
     });
     const allCommentsFromImports = getAllCommentsFromNodes(sortedNodes);
 

--- a/src/utils/get-chunk-type-of-node.ts
+++ b/src/utils/get-chunk-type-of-node.ts
@@ -1,5 +1,6 @@
 import { chunkTypeOther, chunkTypeUnsortable } from '../constants';
 import { GetChunkTypeOfNode } from '../types';
+import { hasIgnoreNextNode } from './has-ignore-next-node';
 
 /**
  * Classifies an import declarations according to its properties, the
@@ -20,11 +21,8 @@ import { GetChunkTypeOfNode } from '../types';
  * @returns The type of the chunk into which the node should be put.
  */
 export const getChunkTypeOfNode: GetChunkTypeOfNode = (node) => {
-    const hasIgnoreNextNode = (node.leadingComments ?? []).some(
-        (comment) => comment.value.trim() === 'prettier-ignore',
-    );
     const hasNoImportedSymbols = node.specifiers.length === 0;
-    return hasIgnoreNextNode || hasNoImportedSymbols
+    return hasIgnoreNextNode(node.leadingComments) || hasNoImportedSymbols
         ? chunkTypeUnsortable
         : chunkTypeOther;
 };

--- a/src/utils/get-code-from-ast.ts
+++ b/src/utils/get-code-from-ast.ts
@@ -9,23 +9,32 @@ import { removeNodesFromOriginalCode } from './remove-nodes-from-original-code';
  * This function generate a code string from the passed nodes.
  * @param nodes All imports, in the sorted order in which they should appear in
  * the generated code.
+ * @param importNodes All nodes that were originally relevant. (This includes nodes that need to be deleted!)
  * @param originalCode The original input code that was passed to this plugin.
  * @param directives All directive prologues from the original code (e.g.
  * `"use strict";`).
  * @param interpreter Optional interpreter directives, if present (e.g.
  * `#!/bin/node`).
  */
-export const getCodeFromAst = (
-    nodes: Statement[],
-    originalCode: string,
-    directives: Directive[],
-    interpreter?: InterpreterDirective | null,
-) => {
+export const getCodeFromAst = ({
+    nodes,
+    importNodes = nodes,
+    originalCode,
+    directives,
+    interpreter,
+}: {
+    nodes: Statement[];
+    importNodes?: Statement[];
+    originalCode: string;
+    directives: Directive[];
+    interpreter?: InterpreterDirective | null;
+}) => {
     const allCommentsFromImports = getAllCommentsFromNodes(nodes);
     const allCommentsFromDirectives = getAllCommentsFromNodes(directives);
 
     const nodesToRemoveFromCode = [
         ...nodes,
+        ...importNodes,
         ...allCommentsFromImports,
         ...allCommentsFromDirectives,
         ...(interpreter ? [interpreter] : []),

--- a/src/utils/get-code-from-ast.ts
+++ b/src/utils/get-code-from-ast.ts
@@ -6,10 +6,9 @@ import { getAllCommentsFromNodes } from './get-all-comments-from-nodes';
 import { removeNodesFromOriginalCode } from './remove-nodes-from-original-code';
 
 /**
- * This function generate a code string from the passed nodes.
- * @param nodes All imports, in the sorted order in which they should appear in
- * the generated code.
- * @param importNodes All nodes that were originally relevant. (This includes nodes that need to be deleted!)
+ * This function generates a code string from the passed nodes.
+ * @param nodesToOutput The remaining imports which should be rendered. (Node specifiers & types may be mutated)
+ * @param allOriginalImportNodes All import nodes that were originally relevant. (This includes nodes that need to be deleted!)
  * @param originalCode The original input code that was passed to this plugin.
  * @param directives All directive prologues from the original code (e.g.
  * `"use strict";`).
@@ -17,24 +16,24 @@ import { removeNodesFromOriginalCode } from './remove-nodes-from-original-code';
  * `#!/bin/node`).
  */
 export const getCodeFromAst = ({
-    nodes,
-    importNodes = nodes,
+    nodesToOutput,
+    allOriginalImportNodes = nodesToOutput,
     originalCode,
     directives,
     interpreter,
 }: {
-    nodes: Statement[];
-    importNodes?: Statement[];
+    nodesToOutput: Statement[];
+    allOriginalImportNodes?: Statement[];
     originalCode: string;
     directives: Directive[];
     interpreter?: InterpreterDirective | null;
 }) => {
-    const allCommentsFromImports = getAllCommentsFromNodes(nodes);
+    const allCommentsFromImports = getAllCommentsFromNodes(nodesToOutput);
     const allCommentsFromDirectives = getAllCommentsFromNodes(directives);
 
     const nodesToRemoveFromCode = [
-        ...nodes,
-        ...importNodes,
+        ...nodesToOutput,
+        ...allOriginalImportNodes,
         ...allCommentsFromImports,
         ...allCommentsFromDirectives,
         ...(interpreter ? [interpreter] : []),
@@ -48,7 +47,7 @@ export const getCodeFromAst = ({
 
     const newAST = file({
         type: 'Program',
-        body: nodes,
+        body: nodesToOutput,
         directives: directives,
         sourceType: 'module',
         interpreter: interpreter,

--- a/src/utils/get-import-flavor-of-node.ts
+++ b/src/utils/get-import-flavor-of-node.ts
@@ -10,7 +10,7 @@ import type { GetImportFlavorOfNode } from '../types';
  * Classifies nodes by import-flavor, primarily informing whether the node is a candidate for merging
  *
  * @param node
- * @returns {("prettier-ignore"|"regular"|"side-effect"|"type")}
+ * @returns the flavor of the import node
  */
 export const getImportFlavorOfNode: GetImportFlavorOfNode = (node) => {
     const hasIgnoreNextNode = (node.leadingComments ?? []).some(

--- a/src/utils/get-import-flavor-of-node.ts
+++ b/src/utils/get-import-flavor-of-node.ts
@@ -5,6 +5,7 @@ import {
     importFlavorValue,
 } from '../constants';
 import type { GetImportFlavorOfNode } from '../types';
+import { hasIgnoreNextNode } from './has-ignore-next-node';
 
 /**
  * Classifies nodes by import-flavor, primarily informing whether the node is a candidate for merging
@@ -13,10 +14,7 @@ import type { GetImportFlavorOfNode } from '../types';
  * @returns the flavor of the import node
  */
 export const getImportFlavorOfNode: GetImportFlavorOfNode = (node) => {
-    const hasIgnoreNextNode = (node.leadingComments ?? []).some(
-        (comment) => comment.value.trim() === 'prettier-ignore',
-    );
-    if (hasIgnoreNextNode) {
+    if (hasIgnoreNextNode(node.leadingComments)) {
         return importFlavorIgnore;
     }
     if (node.specifiers.length === 0) {

--- a/src/utils/get-import-flavor-of-node.ts
+++ b/src/utils/get-import-flavor-of-node.ts
@@ -1,0 +1,29 @@
+import {
+    importFlavorIgnore,
+    importFlavorRegular,
+    importFlavorSideEffect,
+    importFlavorType,
+} from '../constants';
+import type { GetImportFlavorOfNode } from '../types';
+
+/**
+ * Classifies nodes by import-flavor, primarily informing whether the node is a candidate for merging
+ *
+ * @param node
+ * @returns {("prettier-ignore"|"regular"|"side-effect"|"type")}
+ */
+export const getImportFlavorOfNode: GetImportFlavorOfNode = (node) => {
+    const hasIgnoreNextNode = (node.leadingComments ?? []).some(
+        (comment) => comment.value.trim() === 'prettier-ignore',
+    );
+    if (hasIgnoreNextNode) {
+        return importFlavorIgnore;
+    }
+    if (node.specifiers.length === 0) {
+        return importFlavorSideEffect;
+    }
+    if (node.importKind === 'type') {
+        return importFlavorType;
+    }
+    return importFlavorRegular;
+};

--- a/src/utils/get-import-flavor-of-node.ts
+++ b/src/utils/get-import-flavor-of-node.ts
@@ -1,8 +1,8 @@
 import {
     importFlavorIgnore,
-    importFlavorRegular,
     importFlavorSideEffect,
     importFlavorType,
+    importFlavorValue,
 } from '../constants';
 import type { GetImportFlavorOfNode } from '../types';
 
@@ -25,5 +25,5 @@ export const getImportFlavorOfNode: GetImportFlavorOfNode = (node) => {
     if (node.importKind === 'type') {
         return importFlavorType;
     }
-    return importFlavorRegular;
+    return importFlavorValue;
 };

--- a/src/utils/get-sorted-nodes.ts
+++ b/src/utils/get-sorted-nodes.ts
@@ -3,6 +3,7 @@ import { GetSortedNodes, ImportChunk, ImportOrLine } from '../types';
 import { adjustCommentsOnSortedNodes } from './adjust-comments-on-sorted-nodes';
 import { getChunkTypeOfNode } from './get-chunk-type-of-node';
 import { getSortedNodesByImportOrder } from './get-sorted-nodes-by-import-order';
+import { mergeNodesWithMatchingImportFlavors } from './merge-nodes-with-matching-flavors';
 
 /**
  * This function returns the given nodes, sorted in the order as indicated by
@@ -16,12 +17,11 @@ import { getSortedNodesByImportOrder } from './get-sorted-nodes-by-import-order'
  * between the side effect nodes according to the given options.
  * @param nodes All import nodes that should be sorted.
  * @param options Options to influence the behavior of the sorting algorithm.
+ *
+ * @returns A sorted array of the remaining import nodes
  */
-export const getSortedNodes: GetSortedNodes = (
-    nodes,
-    options,
-): ImportOrLine[] => {
-    const { importOrderSeparation } = options;
+export const getSortedNodes: GetSortedNodes = (nodes, options) => {
+    const { importOrderSeparation, importOrderMergeDuplicateImports } = options;
 
     // Split nodes at each boundary between a side-effect node and a
     // non-side-effect node, keeping both types of nodes together.
@@ -48,8 +48,11 @@ export const getSortedNodes: GetSortedNodes = (
             // do not sort side effect nodes
             finalNodes.push(...chunk.nodes);
         } else {
+            const nodes = importOrderMergeDuplicateImports
+                ? mergeNodesWithMatchingImportFlavors(chunk.nodes)
+                : chunk.nodes;
             // sort non-side effect nodes
-            const sorted = getSortedNodesByImportOrder(chunk.nodes, options);
+            const sorted = getSortedNodesByImportOrder(nodes, options);
             finalNodes.push(...sorted);
         }
         if (importOrderSeparation) {

--- a/src/utils/has-ignore-next-node.ts
+++ b/src/utils/has-ignore-next-node.ts
@@ -1,0 +1,9 @@
+import type { Comment } from '@babel/types';
+
+/**
+ * Detects if `// prettier-ignore` is present in the provided array of comments.
+ */
+export const hasIgnoreNextNode = (comments: readonly Comment[] | null) =>
+    (comments ?? []).some(
+        (comment) => comment.value.trim() === 'prettier-ignore',
+    );

--- a/src/utils/merge-nodes-with-matching-flavors.ts
+++ b/src/utils/merge-nodes-with-matching-flavors.ts
@@ -18,6 +18,10 @@ function isMergeableFlavor(flavor: string): flavor is MergeableFlavor {
     return mergeableImportFlavors.includes(flavor as MergeableFlavor);
 }
 
+/**
+ * Builds an object map of import declarations which can be merged together,
+ * grouped by whether they are type or value import declarations.
+ */
 function selectMergeableNodesByImportFlavor(
     nodes: ImportDeclaration[],
 ): Record<MergeableFlavor, ImportDeclaration[]> {
@@ -38,15 +42,23 @@ function selectMergeableNodesByImportFlavor(
     );
 }
 
+/**
+ * Returns the "source" (i.e. module name or path) of an import declaration
+ *
+ * e.g.: `import foo from "./foo";` -- "./foo" is the source.
+ */
 function selectNodeImportSource(node: ImportDeclaration) {
     return node.source.value;
 }
 
+/** import * as Namespace from "someModule" */
 function nodeIsImportNamespaceSpecifier(
     node: ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier,
 ): node is ImportNamespaceSpecifier {
     return node.type === 'ImportNamespaceSpecifier';
 }
+
+/** import Default from "someModule" */
 function nodeIsImportDefaultSpecifier(
     node: ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier,
 ): node is ImportDefaultSpecifier {
@@ -82,6 +94,8 @@ function mergeIsSafe(
 }
 
 /**
+ * Mutates the modeToKeep, adding the import specifiers and comments from the nodeToForget.
+ *
  * @returns (true to delete node | false to keep node)
  */
 function mergeNodes(

--- a/src/utils/merge-nodes-with-matching-flavors.ts
+++ b/src/utils/merge-nodes-with-matching-flavors.ts
@@ -118,17 +118,17 @@ function mergeNodes(
  */
 function mutateContextAndMerge({
     context,
-    deleteContext,
+    nodesToDelete,
     insertableNode,
 }: {
     context: Record<string, ImportDeclaration>;
-    deleteContext: ImportDeclaration[];
+    nodesToDelete: ImportDeclaration[];
     insertableNode: ImportDeclaration;
 }) {
     const source = selectNodeImportSource(insertableNode);
     if (context[source]) {
         if (mergeNodes(context[source], insertableNode)) {
-            deleteContext.push(insertableNode);
+            nodesToDelete.push(insertableNode);
         }
     } else {
         context[source] = insertableNode;
@@ -157,7 +157,7 @@ export const mergeNodesWithMatchingImportFlavors: MergeNodesWithMatchingImportFl
             for (const insertableNode of group) {
                 mutateContextAndMerge({
                     context,
-                    deleteContext: nodesToDelete,
+                    nodesToDelete,
                     insertableNode,
                 });
             }

--- a/src/utils/merge-nodes-with-matching-flavors.ts
+++ b/src/utils/merge-nodes-with-matching-flavors.ts
@@ -7,8 +7,8 @@ import type {
 } from '@babel/types';
 
 import {
-    importFlavorRegular,
     importFlavorType,
+    importFlavorValue,
     mergeableImportFlavors,
 } from '../constants';
 import type { MergeNodesWithMatchingImportFlavors } from '../types';
@@ -31,7 +31,7 @@ function selectMergeableNodesByImportFlavor(
             return groups;
         },
         {
-            [importFlavorRegular]: [] as ImportDeclaration[],
+            [importFlavorValue]: [] as ImportDeclaration[],
             [importFlavorType]: [] as ImportDeclaration[],
         },
     );

--- a/src/utils/merge-nodes-with-matching-flavors.ts
+++ b/src/utils/merge-nodes-with-matching-flavors.ts
@@ -94,7 +94,8 @@ function mergeNodes(
 
     nodeToKeep.specifiers.push(...nodeToForget.specifiers);
 
-    // The line numbers will be all messed up. Is this a problem?
+    // These mutations don't update the line numbers, and that's crucial for moving things around.
+    // To get updated line-numbers you would need to re-parse the code after these changes are rendered!
     nodeToKeep.leadingComments = [
         ...(nodeToKeep.leadingComments || []),
         ...(nodeToForget.leadingComments || []),

--- a/src/utils/merge-nodes-with-matching-flavors.ts
+++ b/src/utils/merge-nodes-with-matching-flavors.ts
@@ -1,5 +1,4 @@
 import type {
-    EmptyStatement,
     ImportDeclaration,
     ImportDefaultSpecifier,
     ImportNamespaceSpecifier,
@@ -22,7 +21,9 @@ function isMergeableFlavor(flavor: string): flavor is MergeableFlavor {
 function selectMergeableNodesByImportFlavor(
     nodes: ImportDeclaration[],
 ): Record<MergeableFlavor, ImportDeclaration[]> {
-    return nodes.reduce(
+    return nodes.reduce<
+        Record<typeof mergeableImportFlavors[number], ImportDeclaration[]>
+    >(
         (groups, node) => {
             const flavor = getImportFlavorOfNode(node);
             if (isMergeableFlavor(flavor)) {
@@ -31,8 +32,8 @@ function selectMergeableNodesByImportFlavor(
             return groups;
         },
         {
-            [importFlavorValue]: [] as ImportDeclaration[],
-            [importFlavorType]: [] as ImportDeclaration[],
+            [importFlavorValue]: [],
+            [importFlavorType]: [],
         },
     );
 }

--- a/src/utils/merge-nodes-with-matching-flavors.ts
+++ b/src/utils/merge-nodes-with-matching-flavors.ts
@@ -1,0 +1,166 @@
+import type {
+    EmptyStatement,
+    ImportDeclaration,
+    ImportDefaultSpecifier,
+    ImportNamespaceSpecifier,
+    ImportSpecifier,
+} from '@babel/types';
+
+import {
+    importFlavorRegular,
+    importFlavorType,
+    mergeableImportFlavors,
+} from '../constants';
+import type { MergeNodesWithMatchingImportFlavors } from '../types';
+import { getImportFlavorOfNode } from './get-import-flavor-of-node';
+
+type MergeableFlavor = typeof mergeableImportFlavors[number];
+function isMergeableFlavor(flavor: string): flavor is MergeableFlavor {
+    return mergeableImportFlavors.includes(flavor as MergeableFlavor);
+}
+
+function selectMergeableNodesByImportFlavor(
+    nodes: ImportDeclaration[],
+): Record<MergeableFlavor, ImportDeclaration[]> {
+    return nodes.reduce(
+        (groups, node) => {
+            const flavor = getImportFlavorOfNode(node);
+            if (isMergeableFlavor(flavor)) {
+                groups[flavor].push(node);
+            }
+            return groups;
+        },
+        {
+            [importFlavorRegular]: [] as ImportDeclaration[],
+            [importFlavorType]: [] as ImportDeclaration[],
+        },
+    );
+}
+
+function selectNodeImportSource(node: ImportDeclaration) {
+    return node.source.value;
+}
+
+function nodeIsImportNamespaceSpecifier(
+    node: ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier,
+): node is ImportNamespaceSpecifier {
+    return node.type === 'ImportNamespaceSpecifier';
+}
+function nodeIsImportDefaultSpecifier(
+    node: ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier,
+): node is ImportDefaultSpecifier {
+    return node.type === 'ImportDefaultSpecifier';
+}
+
+/** Return false if the merge will produce an invalid result */
+function mergeIsSafe(
+    nodeToKeep: ImportDeclaration,
+    nodeToForget: ImportDeclaration,
+) {
+    if (
+        nodeToKeep.specifiers.some(nodeIsImportNamespaceSpecifier) ||
+        nodeToForget.specifiers.some(nodeIsImportNamespaceSpecifier)
+    ) {
+        // An `import * as Foo` namespace specifier cannot be merged
+        //   with other import expressions.
+        return false;
+    }
+    if (
+        nodeToKeep.specifiers.some(nodeIsImportDefaultSpecifier) &&
+        nodeToForget.specifiers.some(nodeIsImportDefaultSpecifier)
+    ) {
+        // Two `import Foo from` specifiers cannot be merged trivially.
+        // -- Notice: this is *not* import {default as Foo1, default as Foo2} -- that's legal!
+        //
+        // Future work could convert `import Foo1 from 'a'; import Foo2 from 'a';
+        //  into `import {default as Foo1, default as Foo2} from 'a';`
+        // But since this runs the risk of making code longer, this won't be in v1.
+        return false;
+    }
+    return true;
+}
+
+/**
+ * @returns (true to delete node | false to keep node)
+ */
+function mergeNodes(
+    nodeToKeep: ImportDeclaration,
+    nodeToForget: ImportDeclaration,
+) {
+    if (!mergeIsSafe(nodeToKeep, nodeToForget)) {
+        return false;
+    }
+
+    nodeToKeep.specifiers.push(...nodeToForget.specifiers);
+
+    // The line numbers will be all messed up. Is this a problem?
+    nodeToKeep.leadingComments = [
+        ...(nodeToKeep.leadingComments || []),
+        ...(nodeToForget.leadingComments || []),
+    ];
+    nodeToKeep.innerComments = [
+        ...(nodeToKeep.innerComments || []),
+        ...(nodeToForget.innerComments || []),
+    ];
+    nodeToKeep.trailingComments = [
+        ...(nodeToKeep.trailingComments || []),
+        ...(nodeToForget.trailingComments || []),
+    ];
+
+    return true;
+}
+
+/**
+ * Modifies context, deleteContext,
+ * case A: context has no node for an import source, then it's assigned.
+ * case B: context has a node for an import source, then it's merged, and old node is added to deleteContext.
+ */
+function mutateContextAndMerge({
+    context,
+    deleteContext,
+    insertableNode,
+}: {
+    context: Record<string, ImportDeclaration>;
+    deleteContext: ImportDeclaration[];
+    insertableNode: ImportDeclaration;
+}) {
+    const source = selectNodeImportSource(insertableNode);
+    if (context[source]) {
+        if (mergeNodes(context[source], insertableNode)) {
+            deleteContext.push(insertableNode);
+        }
+    } else {
+        context[source] = insertableNode;
+    }
+}
+
+/**
+ * Accepts an array of nodes from a given chunk, and merges candidates that have a matching import-flavor
+ *
+ * In other words each group will be merged if they have the same source:
+ * - `import type` expressions from the same source
+ * - `import Name, {a, b}` from the same source
+ *
+ * `import type {Foo}` expressions won't be converted into `import {type Foo}` or vice versa
+ */
+export const mergeNodesWithMatchingImportFlavors: MergeNodesWithMatchingImportFlavors =
+    (input) => {
+        const nodesToDelete: ImportDeclaration[] = [];
+
+        for (const group of Object.values(
+            selectMergeableNodesByImportFlavor(input),
+        )) {
+            // Defined in loop to reset so we don't merge across groups
+            const context: Record<string, ImportDeclaration> = {};
+
+            for (const insertableNode of group) {
+                mutateContextAndMerge({
+                    context,
+                    deleteContext: nodesToDelete,
+                    insertableNode,
+                });
+            }
+        }
+
+        return input.filter((n) => !nodesToDelete.includes(n));
+    };


### PR DESCRIPTION
This PR implements import declaration merging for duplicate imports.

- I had to adjust `getCodeFromAST` so that we could still provide the original nodes, even if some of the nodes were being deleted.
- It leverages the existing chunking logic, so if there's a `side-effect` import, or a `prettier-ignore` import, it won't merge across that boundary.
- I did not implement conversion of `import type { stuff }` into `import { type stuff }` as it was not obvious when this would be wise. If we want to control that with an additional config option, something like `importOrderMergeTypeStyle: "none" | "to-normal-import" | "unmerge"` I could be convinced. I forsee people wanting opposite sides of the coin for that one.

Please let me know what you think and if there's any edge-cases I missed!