### PR TITLE
Maintenance: use fine-grained lodash-imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,11 +50,13 @@
         "@babel/traverse": "^7.17.3",
         "@babel/types": "^7.17.0",
         "javascript-natural-sort": "0.7.1",
-        "lodash": "^4.17.21"
+        "lodash.clone": "^4.5.0",
+        "lodash.isequal": "^4.5.0"
     },
     "devDependencies": {
         "@types/jest": "^27.4.1",
-        "@types/lodash": "4.14.168",
+        "@types/lodash.clone": "4.5.7",
+        "@types/lodash.isequal": "4.5.6",
         "@types/node": "^17.0.21",
         "jest": "^27.5.1",
         "prettier": "2.6.0",

--- a/src/utils/adjust-comments-on-sorted-nodes.ts
+++ b/src/utils/adjust-comments-on-sorted-nodes.ts
@@ -1,5 +1,6 @@
 import { ImportDeclaration, addComments, removeComments } from '@babel/types';
-import { clone, isEqual } from 'lodash';
+import clone from 'lodash.clone';
+import isEqual from 'lodash.isequal';
 
 import { ImportOrLine } from '../types';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -582,10 +582,24 @@
     jest-matcher-utils "^27.0.0"
     pretty-format "^27.0.0"
 
-"@types/lodash@4.14.168":
-  version "4.14.168"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
-  integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
+"@types/lodash.clone@4.5.7":
+  version "4.5.7"
+  resolved "https://registry.yarnpkg.com/@types/lodash.clone/-/lodash.clone-4.5.7.tgz#110e28a71b3328c24d367162f48ae6aa9dab1973"
+  integrity sha512-jugWYM+xBUQCpWbn7p6BSbf8bRMHtJYnEIGZYngbStaU0aN4VFgAAkGgsc+MtHuepBOmjyUGiGv+dHnQQIGLZA==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash.isequal@4.5.6":
+  version "4.5.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.isequal/-/lodash.isequal-4.5.6.tgz#ff42a1b8e20caa59a97e446a77dc57db923bc02b"
+  integrity sha512-Ww4UGSe3DmtvLLJm2F16hDwEQSv7U0Rr8SujLUA2wHI2D2dm8kPu6Et+/y303LfjTIwSBKXB/YTUcAKpem/XEg==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.182"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.182.tgz#05301a4d5e62963227eaafe0ce04dd77c54ea5c2"
+  integrity sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==
 
 "@types/node@*", "@types/node@^17.0.21":
   version "17.0.21"
@@ -1882,12 +1896,22 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash.clone@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clone/-/lodash.clone-4.5.0.tgz#195870450f5a13192478df4bc3d23d2dea1907b6"
+  integrity sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=
+
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
+
 lodash.memoize@4.x:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
-lodash@^4.17.21, lodash@^4.7.0:
+lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
Lodash is a huge and chunky module. If we directly specify which methods we need from it, we can avoid a bit of the always-keep-it-up-to-date treadmill.

Further investigation could be done to see if we really even need the `clone`/`isEqual` methods from lodash, but at least with this PR change we put a soft fence around it to keep from panicking if lodash has security incidents. And to keep it from spreading 😉.

Not a big deal if you don't want to drop it, since the version of whatwg-url that is used by jsdom used by jest still needs it (even if newer versions don't), but I thought I'd provide a PR.

I'm aware that in lodash v5 they claim they will stop deploying the individual module packages, but that argument is based on "runtime package bundling" arguments, rather than on the maintenance concerns.