### PR TITLE
Avoid initial new line when using custom group separator

### DIFF
--- a/src/utils/get-sorted-nodes-by-import-order.ts
+++ b/src/utils/get-sorted-nodes-by-import-order.ts
@@ -70,8 +70,13 @@ export const getSortedNodesByImportOrder: GetSortedNodes = (nodes, options) => {
     for (const group of importOrder) {
         // If it's a custom separator, all we need to do is add a newline
         if (isCustomGroupSeparator(group)) {
+            const lastNode = finalNodes[finalNodes.length - 1];
+            // Avoid empty new line if first group is empty
+            if (!lastNode) {
+                continue;
+            }
             // Don't add multiple newlines
-            if (isLastNodeANewline(finalNodes)) {
+            if (isNodeANewline(lastNode)) {
                 continue;
             }
             finalNodes.push(newLineNode);
@@ -111,7 +116,6 @@ function isCustomGroupSeparator(pattern: string) {
     return pattern.trim() === '';
 }
 
-function isLastNodeANewline(nodes: ImportOrLine[]) {
-    const lastNode = nodes[nodes.length - 1];
-    return lastNode?.type === 'ExpressionStatement';
+function isNodeANewline(node: ImportOrLine) {
+    return node.type === 'ExpressionStatement';
 }

--- a/tests/ImportsSeparatedByEmptyRegex/__snapshots__/ppsi.spec.js.snap
+++ b/tests/ImportsSeparatedByEmptyRegex/__snapshots__/ppsi.spec.js.snap
@@ -241,7 +241,6 @@ import fourLevelRelativePath from "../../../../fourLevelRelativePath";
 import something from "@server/something";
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // I am top level comment
-
 import abc from "@core/abc";
 import otherthing from "@core/otherthing";
 import something from "@server/something";


### PR DESCRIPTION
I think this screenshot will highlight what I feel like an inconsistency:

<img width="1613" alt="Screenshot 2022-05-30 at 15 15 22" src="https://user-images.githubusercontent.com/14235743/171000046-9d7064f1-6e86-49a1-b6b0-98e7d1b5a729.png">
