### PR TITLE
Fix: broken lodash import

### DIFF
--- a/src/utils/get-sorted-nodes-by-import-order.ts
+++ b/src/utils/get-sorted-nodes-by-import-order.ts
@@ -1,4 +1,4 @@
-import { clone } from 'lodash';
+import clone from 'lodash.clone';
 
 import {
     BUILTIN_MODULES,


### PR DESCRIPTION
I think another lodash import was added after refactoring to use more fine-grained lodash import in https://github.com/IanVS/prettier-plugin-sort-imports/pull/21 