### PR TITLE
Upgrade to Prettier 3 in dev dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [14.x, 16.x, 18.x]
+        node: [16.x, 18.x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/package.json
+++ b/package.json
@@ -59,11 +59,11 @@
         "@types/lodash.isequal": "4.5.6",
         "@types/node": "^17.0.21",
         "jest": "^29.2.2",
-        "prettier": "3.0.0-alpha.3",
+        "prettier": "^3.0.0-alpha.4",
         "ts-jest": "^29.0.3",
         "typescript": "4.8.4"
     },
     "peerDependencies": {
-        "prettier": "2.x"
+        "prettier": "2.x || >=3.0.0-alpha.4"
     }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "compile": "tsc",
         "preexample": "yarn run compile",
         "example": "prettier --config ./examples/.prettierrc --plugin lib/src/index.js",
-        "test": "jest -i",
+        "test": "NODE_OPTIONS=--experimental-vm-modules jest -i",
         "type-check": "tsc --noEmit",
         "prepublishOnly": "npm run compile && npm run test"
     },
@@ -59,7 +59,7 @@
         "@types/lodash.isequal": "4.5.6",
         "@types/node": "^17.0.21",
         "jest": "^29.2.2",
-        "prettier": "2.7.1",
+        "prettier": "3.0.0-alpha.3",
         "ts-jest": "^29.0.3",
         "typescript": "4.8.4"
     },

--- a/src/utils/__tests__/get-code-from-ast.spec.ts
+++ b/src/utils/__tests__/get-code-from-ast.spec.ts
@@ -4,7 +4,7 @@ import { getCodeFromAst } from '../get-code-from-ast';
 import { getImportNodes } from '../get-import-nodes';
 import { getSortedNodes } from '../get-sorted-nodes';
 
-it('sorts imports correctly', () => {
+it('sorts imports correctly', async () => {
     const code = `// first comment
 // second comment
 import z from 'z';
@@ -30,7 +30,7 @@ import a from 'a';
         originalCode: code,
         directives: [],
     });
-    expect(format(formatted, { parser: 'babel' })).toEqual(
+    expect(await format(formatted, { parser: 'babel' })).toEqual(
         `// first comment
 // second comment
 import a from "a";
@@ -43,7 +43,7 @@ import z from "z";
     );
 });
 
-it('merges duplicate imports correctly', () => {
+it('merges duplicate imports correctly', async () => {
     const code = `// first comment
 // second comment
 import z from 'z';
@@ -73,7 +73,7 @@ import type {See} from 'c';
         originalCode: code,
         directives: [],
     });
-    expect(format(formatted, { parser: 'babel' })).toEqual(
+    expect(await format(formatted, { parser: 'babel' })).toEqual(
         `// first comment
 // second comment
 import a, { b, type Bee } from "a";

--- a/src/utils/__tests__/merge-nodes-with-matching-flavors.spec.ts
+++ b/src/utils/__tests__/merge-nodes-with-matching-flavors.spec.ts
@@ -15,7 +15,7 @@ const defaultOptions = {
     importOrderSortSpecifiers: true,
 };
 
-it('should merge duplicate imports within a given chunk', () => {
+it('should merge duplicate imports within a given chunk', async () => {
     const code = `
     import type { A } from 'a';
     import { Junk } from 'junk-group-1'
@@ -60,7 +60,7 @@ it('should merge duplicate imports within a given chunk', () => {
         directives: [],
     });
 
-    expect(format(formatted, { parser: 'babel' }))
+    expect(await format(formatted, { parser: 'babel' }))
         .toEqual(`import type { A, B } from "a";
 import { Junk } from "junk-group-1";
 
@@ -89,7 +89,7 @@ import { Junk2 } from "junk-group-2";
 `);
 });
 
-it('should merge type imports into regular imports', () => {
+it('should merge type imports into regular imports', async () => {
     const code = `
     // Preserves 'import type'
     import type { A1 } from 'a';
@@ -120,7 +120,7 @@ it('should merge type imports into regular imports', () => {
         directives: [],
     });
 
-    expect(format(formatted, { parser: 'babel' }))
+    expect(await format(formatted, { parser: 'babel' }))
         .toEqual(`// Preserves 'import type'
 import type { A1, A2 } from "a";
 // Preserves 'import value'
@@ -132,7 +132,7 @@ import { D1, type D2 } from "d";
 `);
 });
 
-it('should combine type import and default import', () => {
+it('should combine type import and default import', async () => {
     const code = `
 import type {MyType} from './source';
 import defaultValue from './source';
@@ -153,12 +153,12 @@ import defaultValue from './source';
         directives: [],
     });
 
-    expect(format(formatted, { parser: 'babel' }))
+    expect(await format(formatted, { parser: 'babel' }))
         .toEqual(`import defaultValue, { type MyType } from "./source";
 `);
 });
 
-it('should not combine type import and namespace import', () => {
+it('should not combine type import and namespace import', async () => {
     const code = `
 import type {MyType} from './source';
 import * as Namespace from './source';
@@ -179,13 +179,13 @@ import * as Namespace from './source';
         directives: [],
     });
 
-    expect(format(formatted, { parser: 'babel' }))
+    expect(await format(formatted, { parser: 'babel' }))
         .toEqual(`import type { MyType } from "./source";
 import * as Namespace from "./source";
 `);
 });
 
-it('should support aliased named imports', () => {
+it('should support aliased named imports', async () => {
     const code = `
 import type {MyType} from './source';
 import {value as alias} from './source';
@@ -206,12 +206,12 @@ import {value as alias} from './source';
         directives: [],
     });
 
-    expect(format(formatted, { parser: 'babel' }))
+    expect(await format(formatted, { parser: 'babel' }))
         .toEqual(`import { value as alias, type MyType } from "./source";
 `);
 });
 
-it('should combine multiple imports from the same source', () => {
+it('should combine multiple imports from the same source', async () => {
     const code = `
 import type {MyType, SecondType} from './source';
 import {value, SecondValue} from './source';
@@ -232,12 +232,12 @@ import {value, SecondValue} from './source';
         directives: [],
     });
 
-    expect(format(formatted, { parser: 'babel' }))
+    expect(await format(formatted, { parser: 'babel' }))
         .toEqual(`import { SecondValue, value, type MyType, type SecondType } from "./source";
 `);
 });
 
-it('should combine multiple groups of imports', () => {
+it('should combine multiple groups of imports', async () => {
     const code = `
 import type {MyType} from './source';
 import type {OtherType} from './other';
@@ -260,13 +260,13 @@ import {otherValue} from './other';
         directives: [],
     });
 
-    expect(format(formatted, { parser: 'babel' }))
+    expect(await format(formatted, { parser: 'babel' }))
         .toEqual(`import { otherValue, type OtherType } from "./other";
 import { value, type MyType } from "./source";
 `);
 });
 
-it('should combine multiple imports statements from the same source', () => {
+it('should combine multiple imports statements from the same source', async () => {
     const code = `
 import type {MyType} from './source';
 import type {SecondType} from './source';
@@ -289,12 +289,12 @@ import {SecondValue} from './source';
         directives: [],
     });
 
-    expect(format(formatted, { parser: 'babel' }))
+    expect(await format(formatted, { parser: 'babel' }))
         .toEqual(`import { SecondValue, value, type MyType, type SecondType } from "./source";
 `);
 });
 
-it('should not impact imports from different sources', () => {
+it('should not impact imports from different sources', async () => {
     const code = `
 import type {MyType} from './source';
 import type {OtherType} from './other';
@@ -317,14 +317,14 @@ import {value} from './source';
         directives: [],
     });
 
-    expect(format(formatted, { parser: 'babel' }))
+    expect(await format(formatted, { parser: 'babel' }))
         .toEqual(`import type { OtherType } from "./other";
 import { value, type MyType } from "./source";
 import { thirdValue } from "./third";
 `);
 });
 
-it("doesn't merge duplicate imports if option disabled", () => {
+it("doesn't merge duplicate imports if option disabled", async () => {
     const code = `
     import type { A } from 'a';
     import { Junk } from 'junk-group-1'
@@ -368,7 +368,7 @@ it("doesn't merge duplicate imports if option disabled", () => {
         directives: [],
     });
 
-    expect(format(formatted, { parser: 'babel' }))
+    expect(await format(formatted, { parser: 'babel' }))
         .toEqual(`import type { A } from "a";
 import type { B } from "a";
 import { Junk } from "junk-group-1";
@@ -401,7 +401,7 @@ import { Junk2 } from "junk-group-2";
 `);
 });
 
-it('should not combine default type imports', () => {
+it('should not combine default type imports', async () => {
     const code = `
     import { ComponentProps, useEffect } from "react";
     import type React from "react";
@@ -422,7 +422,7 @@ it('should not combine default type imports', () => {
         directives: [],
     });
 
-    expect(format(formatted, { parser: 'babel' }))
+    expect(await format(formatted, { parser: 'babel' }))
         .toEqual(`import { ComponentProps, useEffect } from "react";
 import type React from "react";
 `);

--- a/src/utils/__tests__/remove-nodes-from-original-code.spec.ts
+++ b/src/utils/__tests__/remove-nodes-from-original-code.spec.ts
@@ -18,7 +18,7 @@ import k from 'k';
 import a from 'a';
 `;
 
-test('it should remove nodes from the original code', () => {
+test('it should remove nodes from the original code', async () => {
     const ast = babelParser(code, { sourceType: 'module' });
     const importNodes = getImportNodes(code);
     const sortedNodes = getSortedNodes(importNodes, {
@@ -42,6 +42,6 @@ test('it should remove nodes from the original code', () => {
         code,
         commentAndImportsToRemoveFromCode,
     );
-    const result = format(codeWithoutImportDeclarations, { parser: 'babel' });
+    const result = await format(codeWithoutImportDeclarations, { parser: 'babel' });
     expect(result).toEqual('');
 });

--- a/test-setup/run_spec.js
+++ b/test-setup/run_spec.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const extname = require('path').extname;
 const prettier = require('prettier');
 
-function run_spec(dirname, parsers, options) {
+async function run_spec(dirname, parsers, options) {
     options = Object.assign(
         {
             plugins: ['./src'],
@@ -18,7 +18,7 @@ function run_spec(dirname, parsers, options) {
         throw new Error(`No parsers were specified for ${dirname}`);
     }
 
-    fs.readdirSync(dirname).forEach((filename) => {
+    for (const filename of fs.readdirSync(dirname)) {
         const path = dirname + '/' + filename;
         if (
             extname(filename) !== '.snap' &&
@@ -31,8 +31,8 @@ function run_spec(dirname, parsers, options) {
             const mergedOptions = Object.assign({}, options, {
                 parser: parsers[0],
             });
-            const output = prettyprint(source, path, mergedOptions);
-            test(`${filename} - ${mergedOptions.parser}-verify`, () => {
+            test(`${filename} - ${mergedOptions.parser}-verify`, async () => {
+                const output = await prettyprint(source, path, mergedOptions);
                 try {
                     expect(
                         raw(source + '~'.repeat(80) + '\n' + output),
@@ -42,21 +42,21 @@ function run_spec(dirname, parsers, options) {
                 }
             });
 
-            parsers.slice(1).forEach((parserName) => {
-                test(`${filename} - ${parserName}-verify`, () => {
+            for (const parserName of parsers.slice(1)) {
+                test(`${filename} - ${parserName}-verify`, async () => {
                     const verifyOptions = Object.assign(mergedOptions, {
                         parser: parserName,
                     });
-                    const verifyOutput = prettyprint(
+                    const verifyOutput = await prettyprint(
                         source,
                         path,
                         verifyOptions,
                     );
                     expect(output).toEqual(verifyOutput);
                 });
-            });
+            }
         }
-    });
+    }
 }
 global.run_spec = run_spec;
 

--- a/tests/Angular/__snapshots__/ppsi.spec.js.snap
+++ b/tests/Angular/__snapshots__/ppsi.spec.js.snap
@@ -60,7 +60,7 @@ export class TemplateController {
     constructor(
         private templateService: TemplateService,
         private _httpService: HttpService,
-        private _canvaskitService: CanvasKitService
+        private _canvaskitService: CanvasKitService,
     ) {
         this.CanvasKit = this._canvaskitService.canvasKit;
         this.requestFile = (url) => {
@@ -207,7 +207,7 @@ export class TemplateController {
     constructor(
         private templateService: TemplateService,
         private _httpService: HttpService,
-        private _canvaskitService: CanvasKitService
+        private _canvaskitService: CanvasKitService,
     ) {
         this.CanvasKit = this._canvaskitService.canvasKit;
         this.requestFile = (url) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2105,10 +2105,10 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-prettier@2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
-  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
+prettier@3.0.0-alpha.3:
+  version "3.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.0-alpha.3.tgz#21c35c12792dc0e1d04dd00efe0976f383928f58"
+  integrity sha512-gYWrMcU3iMwG+PSPU2KnprIKslFDW+mslyA8DCrCASO9z1+rEog82WzoYtP7Kh7QglVepKjl94iJFfRPTens2A==
 
 pretty-format@^29.0.0, pretty-format@^29.2.1:
   version "29.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2105,10 +2105,10 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-prettier@3.0.0-alpha.3:
-  version "3.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.0-alpha.3.tgz#21c35c12792dc0e1d04dd00efe0976f383928f58"
-  integrity sha512-gYWrMcU3iMwG+PSPU2KnprIKslFDW+mslyA8DCrCASO9z1+rEog82WzoYtP7Kh7QglVepKjl94iJFfRPTens2A==
+prettier@^3.0.0-alpha.4:
+  version "3.0.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.0-alpha.4.tgz#eee71d6b520b970f44e4045f2dc772bf6f80815f"
+  integrity sha512-+KeqJv4E5kaRsDRgSx9IeVygLKGHRmcoPvRJvPFp3bC1mw8opsva555gGb8TaJzUiHXoLZcus1EX+nlHPda7Pw==
 
 pretty-format@^29.0.0, pretty-format@^29.2.1:
   version "29.2.1"


### PR DESCRIPTION
This is a bit of a test to see whether we're compatible with prettier 3.  Initially we were broken, due to https://github.com/prettier/prettier/issues/13729.  But that's been addressed in the latest alpha, and tests are now passing.  

I think we could merge and release this prior to the next breaking change.  The only user-facing change in this PR is to peerDependencies, so that folks can start using prettier 3 if they want.  But we might as well hold off, I think, to see how things shake out in prettier, since it sounds like there may be more breaking changes on the way.