### PR TITLE
Fix type/non-type sorting

### DIFF
--- a/src/utils/__tests__/get-import-nodes-matched-group.spec.ts
+++ b/src/utils/__tests__/get-import-nodes-matched-group.spec.ts
@@ -12,6 +12,16 @@ import j from './j';
 import l from './l';
 import a from '@core/a';
 `;
+
+const codeWithTypes = `
+import z from 'z';
+import type T from 't';
+import {b} from 'b';
+import a from './a';
+import type {F} from 'f';
+import type Local from './local';
+`;
+
 test('should return correct matched groups', () => {
     const importNodes = getImportNodes(code);
     const importOrder = [
@@ -52,4 +62,28 @@ test('should return THIRD_PARTY_MODULES as matched group with empty order list',
         );
         expect(matchedGroup).toEqual('<THIRD_PARTY_MODULES>');
     }
+});
+
+test('should sort non-types separately from types if <TYPES> group is present', () => {
+    const importNodes = getImportNodes(codeWithTypes, {
+        plugins: ['typescript'],
+    });
+    const importOrder = ['^[./]', '<TYPES>^[./]', '<TYPES>'];
+
+    let matchedGroups: string[] = [];
+    for (const importNode of importNodes) {
+        const matchedGroup = getImportNodesMatchedGroup(
+            importNode,
+            importOrder,
+        );
+        matchedGroups.push(matchedGroup);
+    }
+    expect(matchedGroups).toEqual([
+        '<THIRD_PARTY_MODULES>',
+        '<TYPES>',
+        '<THIRD_PARTY_MODULES>',
+        '^[./]',
+        '<TYPES>',
+        '<TYPES>^[./]',
+    ]);
 });

--- a/src/utils/get-import-nodes-matched-group.ts
+++ b/src/utils/get-import-nodes-matched-group.ts
@@ -7,6 +7,9 @@ import {
 
 /**
  * Get the regexp group to keep the import nodes.
+ *
+ * This comes near the end of processing, after import declaration nodes have been combined or exploded.
+ *
  * @param node
  * @param importOrder
  */
@@ -36,7 +39,11 @@ export const getImportNodesMatchedGroup = (
                 node.importKind === 'type' &&
                 node.source.value.match(regExp) !== null;
         } else {
-            matched = node.source.value.match(regExp) !== null;
+            // If <TYPES> is being used for any group, and this group doesn't have it, only look for value imports
+            matched = includesTypesSpecialWord
+                ? node.importKind !== 'type' &&
+                  node.source.value.match(regExp) !== null
+                : node.source.value.match(regExp) !== null;
         }
 
         if (matched) return group;

--- a/tests/TypesSpecialWord/__snapshots__/ppsi.spec.js.snap
+++ b/tests/TypesSpecialWord/__snapshots__/ppsi.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`imports-with-mixed-declarations.ts - typescript-verify: imports-with-mixed-declarations.ts 1`] = `
 import a, {type LocalType} from './local-file';
+import type Another from './another-local-file';
 import value, {tp} from 'third-party';
 import {specifier, type ThirdPartyType} from 'third-party';
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -9,9 +10,10 @@ import type { ThirdPartyType } from "third-party";
 
 import value, { tp, specifier } from "third-party";
 
-import type { LocalType } from "./local-file";
-
 import a from "./local-file";
+
+import type Another from "./another-local-file";
+import type { LocalType } from "./local-file";
 
 `;
 
@@ -29,9 +31,9 @@ import type { SpecifierType } from "third-party";
 
 import value, { specifier } from "third-party";
 
+import a from "./local-file";
+
 import type LocalType from "./local-file";
 import type { LocalSpecifierType } from "./local-file";
-
-import a from "./local-file";
 
 `;

--- a/tests/TypesSpecialWord/imports-with-mixed-declarations.ts
+++ b/tests/TypesSpecialWord/imports-with-mixed-declarations.ts
@@ -1,3 +1,4 @@
 import a, {type LocalType} from './local-file';
+import type Another from './another-local-file';
 import value, {tp} from 'third-party';
 import {specifier, type ThirdPartyType} from 'third-party';

--- a/tests/TypesSpecialWord/ppsi.spec.js
+++ b/tests/TypesSpecialWord/ppsi.spec.js
@@ -2,8 +2,8 @@ run_spec(__dirname, ['typescript'], {
     importOrder: [
         '<TYPES>',
         '<THIRD_PARTY_MODULES>',
-        '<TYPES>^[./]',
         '^[./]',
+        '<TYPES>^[./]',
     ],
     importOrderSeparation: true,
     importOrderMergeDuplicateImports: true,


### PR DESCRIPTION
We had a bug, identified by @mattiaz9 in https://github.com/IanVS/prettier-plugin-sort-imports/issues/35#issuecomment-1293903705, which was causing the `"^[./]"` group to include both type and value imports, instead of only value imports.

This PR fixes that bug, and expands both the unit and e2e tests, which fail without this change and pass with it.