### PR TITLE
Fix importOrderCombineTypeAndValueImports for Flow

### DIFF
--- a/src/utils/merge-nodes-with-matching-flavors.ts
+++ b/src/utils/merge-nodes-with-matching-flavors.ts
@@ -76,7 +76,12 @@ function nodeIsImportSpecifier(
 }
 
 function convertImportSpecifierToType(node: ImportSpecifier) {
-    assert(node.importKind === 'value' || node.importKind === 'type');
+    assert(
+        node.importKind === 'value' ||
+            node.importKind === 'type' ||
+            // importKind can be null when using Flow
+            node.importKind === null,
+    );
     node.importKind = 'type';
 }
 

--- a/tests/Flow/__snapshots__/ppsi.spec.js.snap
+++ b/tests/Flow/__snapshots__/ppsi.spec.js.snap
@@ -199,3 +199,18 @@ export function givesAFoo3Obj(): AliasFoo3 {
 }
 
 `;
+
+exports[`imports-with-type-and-value-imports.js - flow-verify: imports-with-type-and-value-imports.js 1`] = `
+/**
+ * @flow
+ */
+
+import type {Foo} from './foo';
+import {fooValue} from './foo';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/**
+ * @flow
+ */
+import { fooValue, type Foo } from "./foo";
+
+`;

--- a/tests/Flow/imports-with-type-and-value-imports.js
+++ b/tests/Flow/imports-with-type-and-value-imports.js
@@ -1,0 +1,6 @@
+/**
+ * @flow
+ */
+
+import type {Foo} from './foo';
+import {fooValue} from './foo';

--- a/tests/Flow/ppsi.spec.js
+++ b/tests/Flow/ppsi.spec.js
@@ -1,5 +1,7 @@
 run_spec(__dirname, ['flow'], {
     importOrder: ['^@core/(.*)$', '^@server/(.*)', '^@ui/(.*)$', '^[./]'],
     importOrderSeparation: true,
-    importOrderParserPlugins: ['flow']
+    importOrderParserPlugins: ['flow'],
+    importOrderMergeDuplicateImports: true,
+    importOrderCombineTypeAndValueImports: true,
 });

--- a/tests/Typescript/__snapshots__/ppsi.spec.js.snap
+++ b/tests/Typescript/__snapshots__/ppsi.spec.js.snap
@@ -182,6 +182,14 @@ export class AppComponent extends BaseComponent {
 
 `;
 
+exports[`imports-with-type-and-value-imports.js - typescript-verify: imports-with-type-and-value-imports.js 1`] = `
+import type {Foo} from './foo';
+import {fooValue} from './foo';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import { fooValue, type Foo } from "./foo";
+
+`;
+
 exports[`imports-with-unsorted-modules.ts - typescript-verify: imports-with-unsorted-modules.ts 1`] = `
 import z from 'z';
 import { isEmpty, concat, flatten } from "lodash-es";

--- a/tests/Typescript/imports-with-type-and-value-imports.js
+++ b/tests/Typescript/imports-with-type-and-value-imports.js
@@ -1,0 +1,2 @@
+import type {Foo} from './foo';
+import {fooValue} from './foo';

--- a/tests/Typescript/ppsi.spec.js
+++ b/tests/Typescript/ppsi.spec.js
@@ -1,5 +1,7 @@
 run_spec(__dirname, ["typescript"], {
     importOrder: ['^@core/(.*)$', '^@server/(.*)', '^@ui/(.*)$', '^[./]'],
     importOrderSeparation: true,
-    importOrderParserPlugins : ['typescript', 'decorators-legacy', 'classProperties']
+    importOrderParserPlugins : ['typescript', 'decorators-legacy', 'classProperties'],
+    importOrderMergeDuplicateImports: true,
+    importOrderCombineTypeAndValueImports: true,
 });


### PR DESCRIPTION
Fixes https://github.com/IanVS/prettier-plugin-sort-imports/issues/56

I needed to loosen the assertion a bit, because Flow's AST does not apparently use an `importKind` of `"value"` for specifiers, instead it is `null`.

I also added an e2e test here, for both Flow and TypeScript.