### PR TITLE
[Breaking] Remove importOrderBuiltinModulesToTop (always true)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Since then more critical features & fixes have been added. As a result, this rep
 -   Do not re-order across side-effect imports
 -   Combine imports from the same source ([`importOrderMergeDuplicateImports`](#importordermergeduplicateimports))
 -   Combine type and value imports ([`importOrderCombineTypeAndValueImports`](#importordercombinetypeandvalueimports))
--   Sort node.js builtin modules to top ([`importOrderBuiltinModulesToTop`](#importorderbuiltinmodulestotop))
+-   Sorts node.js builtin modules to top
 -   Custom import order separation ([`importOrderSeparation`](#importorderseparation))
 
 [We welcome contributions!](./CONTRIBUTING.md)
@@ -35,7 +35,6 @@ Since then more critical features & fixes have been added. As a result, this rep
         -   [`importOrderMergeDuplicateImports`](#importordermergeduplicateimports)
         -   [`importOrderCombineTypeAndValueImports`](#importordercombinetypeandvalueimports)
         -   [`importOrderParserPlugins`](#importorderparserplugins)
-        -   [`importOrderBuiltinModulesToTop`](#importorderbuiltinmodulestotop)
     -   [Prevent imports from being sorted](#prevent-imports-from-being-sorted)
 -   [FAQ / Troubleshooting](#faq--troubleshooting)
 -   [Compatibility](#compatibility)
@@ -131,7 +130,6 @@ module.exports = {
     singleQuote: true,
     semi: true,
     importOrder: ['^@core/(.*)$', '^@server/(.*)$', '^@ui/(.*)$', '^[./]'],
-    importOrderBuiltinModulesToTop: true,
     importOrderCaseInsensitive: true,
     importOrderParserPlugins: ['typescript', 'jsx', 'decorators-legacy'],
     importOrderMergeDuplicateImports: true,
@@ -351,14 +349,6 @@ with options as a JSON string of the plugin array:
 ```json
 "importOrderParserPlugins": []
 ```
-
-#### `importOrderBuiltinModulesToTop`
-
-**type**: `boolean`
-
-**default value:** `false`
-
-A boolean value to enable sorting of [`node builtins`](https://nodejs.org/api/module.html#modulebuiltinmodules) to the top of all import groups.
 
 ### Prevent imports from being sorted
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
+import { builtinModules } from 'module';
+
 import { ParserPlugin } from '@babel/parser';
 import { expressionStatement, stringLiteral } from '@babel/types';
-import { builtinModules } from 'module';
 
 export const flow: ParserPlugin = 'flow';
 export const typescript: ParserPlugin = 'typescript';

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,12 +62,6 @@ export const options: Record<
         default: false,
         description: 'Should specifiers be sorted?',
     },
-    importOrderBuiltinModulesToTop: {
-        type: 'boolean',
-        category: 'Global',
-        default: false,
-        description: 'Should node-builtins be hoisted to the top?',
-    },
     importOrderMergeDuplicateImports: {
         type: 'boolean',
         category: 'Global',

--- a/src/preprocessors/preprocessor.ts
+++ b/src/preprocessors/preprocessor.ts
@@ -12,7 +12,6 @@ export function preprocessor(code: string, options: PrettierOptions): string {
     const {
         importOrderParserPlugins,
         importOrder,
-        importOrderBuiltinModulesToTop,
         importOrderCaseInsensitive,
         importOrderGroupNamespaceSpecifiers,
         importOrderMergeDuplicateImports,
@@ -70,7 +69,6 @@ export function preprocessor(code: string, options: PrettierOptions): string {
 
     const nodesToOutput = getSortedNodes(allOriginalImportNodes, {
         importOrder,
-        importOrderBuiltinModulesToTop,
         importOrderCaseInsensitive,
         importOrderGroupNamespaceSpecifiers,
         importOrderMergeDuplicateImports,

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,6 @@ export type GetSortedNodes = (
     options: Pick<
         PrettierOptions,
         | 'importOrder'
-        | 'importOrderBuiltinModulesToTop'
         | 'importOrderCaseInsensitive'
         | 'importOrderGroupNamespaceSpecifiers'
         | 'importOrderMergeDuplicateImports'

--- a/src/utils/__tests__/get-all-comments-from-nodes.spec.ts
+++ b/src/utils/__tests__/get-all-comments-from-nodes.spec.ts
@@ -11,7 +11,6 @@ const getSortedImportNodes = (code: string, options?: ParserOptions) => {
 
     return getSortedNodes(importNodes, {
         importOrder: [],
-        importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: false,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,

--- a/src/utils/__tests__/get-code-from-ast.spec.ts
+++ b/src/utils/__tests__/get-code-from-ast.spec.ts
@@ -18,7 +18,6 @@ import a from 'a';
     const importNodes = getImportNodes(code);
     const sortedNodes = getSortedNodes(importNodes, {
         importOrder: [],
-        importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: false,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
@@ -60,7 +59,6 @@ import type {See} from 'c';
     const importNodes = getImportNodes(code, { plugins: ['typescript'] });
     const sortedNodes = getSortedNodes(importNodes, {
         importOrder: [],
-        importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: false,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: true,

--- a/src/utils/__tests__/get-sorted-nodes-by-import-order.spec.ts
+++ b/src/utils/__tests__/get-sorted-nodes-by-import-order.spec.ts
@@ -29,7 +29,6 @@ test('it returns all sorted nodes', () => {
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^[./]'],
-        importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: false,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
@@ -39,6 +38,9 @@ test('it returns all sorted nodes', () => {
     }) as ImportDeclaration[];
 
     expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
+        'node:fs/promises',
+        'node:url',
+        'path',
         'BY',
         'Ba',
         'XY',
@@ -47,9 +49,6 @@ test('it returns all sorted nodes', () => {
         'c',
         'g',
         'k',
-        'node:fs/promises',
-        'node:url',
-        'path',
         't',
         'x',
         'z',
@@ -62,6 +61,9 @@ test('it returns all sorted nodes', () => {
                 getSortedNodesModulesNames(importDeclaration.specifiers),
             ),
     ).toEqual([
+        ['fs'],
+        ['url'], // `node:url` comes before `path`
+        ['path'],
         ['BY'],
         ['Ba'],
         ['XY'],
@@ -70,9 +72,6 @@ test('it returns all sorted nodes', () => {
         ['c', 'cD'],
         ['g'],
         ['k', 'kE', 'kB'],
-        ['fs'],
-        ['url'],
-        ['path'],
         ['tC', 'tA', 'tB'],
         ['x'],
         ['z'],
@@ -84,7 +83,6 @@ test('it returns all sorted nodes case-insensitive', () => {
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^[./]'],
-        importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: true,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
@@ -94,15 +92,15 @@ test('it returns all sorted nodes case-insensitive', () => {
     }) as ImportDeclaration[];
 
     expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
+        'node:fs/promises',
+        'node:url',
+        'path',
         'a',
         'Ba',
         'BY',
         'c',
         'g',
         'k',
-        'node:fs/promises',
-        'node:url',
-        'path',
         't',
         'x',
         'Xa',
@@ -117,15 +115,15 @@ test('it returns all sorted nodes case-insensitive', () => {
                 getSortedNodesModulesNames(importDeclaration.specifiers),
             ),
     ).toEqual([
+        ['fs'],
+        ['url'], // `node:url` comes before `path`
+        ['path'],
         ['a'],
         ['Ba'],
         ['BY'],
         ['c', 'cD'],
         ['g'],
         ['k', 'kE', 'kB'],
-        ['fs'],
-        ['url'],
-        ['path'],
         ['tC', 'tA', 'tB'],
         ['x'],
         ['Xa'],
@@ -139,7 +137,6 @@ test('it returns all sorted nodes with sort order', () => {
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^a$', '^t$', '^k$', '^B', '^[./]'],
-        importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: false,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
@@ -149,13 +146,13 @@ test('it returns all sorted nodes with sort order', () => {
     }) as ImportDeclaration[];
 
     expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
+        'node:fs/promises',
+        'node:url',
+        'path',
         'XY',
         'Xa',
         'c',
         'g',
-        'node:fs/promises',
-        'node:url',
-        'path',
         'x',
         'z',
         'a',
@@ -172,13 +169,13 @@ test('it returns all sorted nodes with sort order', () => {
                 getSortedNodesModulesNames(importDeclaration.specifiers),
             ),
     ).toEqual([
+        ['fs'],
+        ['url'], // `node:url` comes before `path`
+        ['path'],
         ['XY'],
         ['Xa'],
         ['c', 'cD'],
         ['g'],
-        ['fs'],
-        ['url'],
-        ['path'],
         ['x'],
         ['z'],
         ['a'],
@@ -194,7 +191,6 @@ test('it returns all sorted nodes with sort order case-insensitive', () => {
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^a$', '^t$', '^k$', '^B', '^[./]'],
-        importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: true,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
@@ -203,11 +199,11 @@ test('it returns all sorted nodes with sort order case-insensitive', () => {
         importOrderSortSpecifiers: false,
     }) as ImportDeclaration[];
     expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
-        'c',
-        'g',
         'node:fs/promises',
         'node:url',
         'path',
+        'c',
+        'g',
         'x',
         'Xa',
         'XY',
@@ -226,11 +222,11 @@ test('it returns all sorted nodes with sort order case-insensitive', () => {
                 getSortedNodesModulesNames(importDeclaration.specifiers),
             ),
     ).toEqual([
+        ['fs'],
+        ['url'], // `node:url` comes before `path`
+        ['path'],
         ['c', 'cD'],
         ['g'],
-        ['fs'],
-        ['url'],
-        ['path'],
         ['x'],
         ['Xa'],
         ['XY'],
@@ -248,7 +244,6 @@ test('it returns all sorted import nodes with sorted import specifiers', () => {
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^a$', '^t$', '^k$', '^B', '^[./]'],
-        importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: false,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
@@ -257,13 +252,13 @@ test('it returns all sorted import nodes with sorted import specifiers', () => {
         importOrderSortSpecifiers: true,
     }) as ImportDeclaration[];
     expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
+        'node:fs/promises',
+        'node:url',
+        'path',
         'XY',
         'Xa',
         'c',
         'g',
-        'node:fs/promises',
-        'node:url',
-        'path',
         'x',
         'z',
         'a',
@@ -280,13 +275,13 @@ test('it returns all sorted import nodes with sorted import specifiers', () => {
                 getSortedNodesModulesNames(importDeclaration.specifiers),
             ),
     ).toEqual([
+        ['fs'],
+        ['url'], // `node:url` comes before `path`
+        ['path'],
         ['XY'],
         ['Xa'],
         ['c', 'cD'],
         ['g'],
-        ['fs'],
-        ['url'],
-        ['path'],
         ['x'],
         ['z'],
         ['a'],
@@ -302,7 +297,6 @@ test('it returns all sorted import nodes with sorted import specifiers with case
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^a$', '^t$', '^k$', '^B', '^[./]'],
-        importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: true,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
@@ -311,11 +305,11 @@ test('it returns all sorted import nodes with sorted import specifiers with case
         importOrderSortSpecifiers: true,
     }) as ImportDeclaration[];
     expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
-        'c',
-        'g',
         'node:fs/promises',
         'node:url',
         'path',
+        'c',
+        'g',
         'x',
         'Xa',
         'XY',
@@ -334,11 +328,11 @@ test('it returns all sorted import nodes with sorted import specifiers with case
                 getSortedNodesModulesNames(importDeclaration.specifiers),
             ),
     ).toEqual([
+        ['fs'],
+        ['url'], // `node:url` comes before `path`
+        ['path'],
         ['c', 'cD'],
         ['g'],
-        ['fs'],
-        ['url'],
-        ['path'],
         ['x'],
         ['Xa'],
         ['XY'],
@@ -352,42 +346,10 @@ test('it returns all sorted import nodes with sorted import specifiers with case
     ]);
 });
 
-test('it returns all sorted nodes with custom third party modules', () => {
-    const result = getImportNodes(code);
-    const sorted = getSortedNodesByImportOrder(result, {
-        importOrder: ['^a$', '<THIRD_PARTY_MODULES>', '^t$', '^k$', '^[./]'],
-        importOrderBuiltinModulesToTop: false,
-        importOrderCaseInsensitive: true,
-        importOrderGroupNamespaceSpecifiers: false,
-        importOrderMergeDuplicateImports: false,
-        importOrderCombineTypeAndValueImports: false,
-        importOrderSeparation: false,
-        importOrderSortSpecifiers: false,
-    }) as ImportDeclaration[];
-    expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
-        'a',
-        'Ba',
-        'BY',
-        'c',
-        'g',
-        'node:fs/promises',
-        'node:url',
-        'path',
-        'x',
-        'Xa',
-        'XY',
-        'z',
-        't',
-        'k',
-        './local',
-    ]);
-});
-
-test('it returns all sorted nodes with namespace specifiers at the top', () => {
+test('it returns all sorted nodes with namespace specifiers at the top (under builtins)', () => {
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^[./]'],
-        importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: false,
         importOrderGroupNamespaceSpecifiers: true,
         importOrderMergeDuplicateImports: false,
@@ -397,8 +359,10 @@ test('it returns all sorted nodes with namespace specifiers at the top', () => {
     }) as ImportDeclaration[];
 
     expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
-        'a',
         'node:fs/promises',
+        'node:url',
+        'path',
+        'a',
         'x',
         'BY',
         'Ba',
@@ -407,8 +371,6 @@ test('it returns all sorted nodes with namespace specifiers at the top', () => {
         'c',
         'g',
         'k',
-        'node:url',
-        'path',
         't',
         'z',
         './local',
@@ -419,7 +381,6 @@ test('it returns all sorted nodes with builtin specifiers at the top, ', () => {
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^[./]'],
-        importOrderBuiltinModulesToTop: true,
         importOrderCaseInsensitive: false,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
@@ -451,7 +412,6 @@ test('it returns all sorted nodes with custom third party modules and builtins a
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^a$', '<THIRD_PARTY_MODULES>', '^t$', '^k$', '^[./]'],
-        importOrderBuiltinModulesToTop: true,
         importOrderCaseInsensitive: true,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
@@ -482,7 +442,6 @@ test('it adds newlines when importOrderSeparation is true', () => {
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^[./]'],
-        importOrderBuiltinModulesToTop: true,
         importOrderCaseInsensitive: true,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
@@ -523,7 +482,6 @@ test('it returns all sorted nodes with custom separation', () => {
             '^k$',
             '^[./]',
         ],
-        importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: true,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
@@ -532,14 +490,14 @@ test('it returns all sorted nodes with custom separation', () => {
         importOrderSortSpecifiers: false,
     }) as ImportDeclaration[];
     expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
+        'node:fs/promises',
+        'node:url',
+        'path',
         'a',
         'Ba',
         'BY',
         'c',
         'g',
-        'node:fs/promises',
-        'node:url',
-        'path',
         'x',
         'Xa',
         'XY',
@@ -562,7 +520,6 @@ test('it allows both importOrderSeparation and custom separation (but why?)', ()
             '^k$',
             '^[./]',
         ],
-        importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: true,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
@@ -571,15 +528,16 @@ test('it allows both importOrderSeparation and custom separation (but why?)', ()
         importOrderSortSpecifiers: false,
     }) as ImportDeclaration[];
     expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
+        'node:fs/promises',
+        'node:url',
+        'path',
+        '',
         'a',
         '',
         'Ba',
         'BY',
         'c',
         'g',
-        'node:fs/promises',
-        'node:url',
-        'path',
         'x',
         'Xa',
         'XY',
@@ -607,7 +565,6 @@ test('it does not add multiple custom import separators', () => {
             '^k$',
             '^[./]',
         ],
-        importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: true,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
@@ -616,14 +573,14 @@ test('it does not add multiple custom import separators', () => {
         importOrderSortSpecifiers: false,
     }) as ImportDeclaration[];
     expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
+        'node:fs/promises',
+        'node:url',
+        'path',
         'a',
         'Ba',
         'BY',
         'c',
         'g',
-        'node:fs/promises',
-        'node:url',
-        'path',
         'x',
         'Xa',
         'XY',

--- a/src/utils/__tests__/get-sorted-nodes.spec.ts
+++ b/src/utils/__tests__/get-sorted-nodes.spec.ts
@@ -30,7 +30,6 @@ test('it returns all sorted nodes, preserving the order side effect nodes', () =
     const result = getImportNodes(code);
     const sorted = getSortedNodes(result, {
         importOrder: [],
-        importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: false,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
@@ -48,12 +47,12 @@ test('it returns all sorted nodes, preserving the order side effect nodes', () =
         'z',
         'se4',
         'se1',
+        'path', // Builtins are not sorted past side-effects either
         'BY',
         'Ba',
         'XY',
         'Xa',
         'a',
-        'path',
         'x',
         'se2',
         '',
@@ -73,12 +72,12 @@ test('it returns all sorted nodes, preserving the order side effect nodes', () =
         ['z'],
         [],
         [],
+        ['path'],
         ['BY'],
         ['Ba'],
         ['XY'],
         ['Xa'],
         ['a'],
-        ['path'],
         ['x'],
         [],
     ]);

--- a/src/utils/__tests__/merge-nodes-with-matching-flavors.spec.ts
+++ b/src/utils/__tests__/merge-nodes-with-matching-flavors.spec.ts
@@ -7,7 +7,6 @@ import { getSortedNodes } from '../get-sorted-nodes';
 
 const defaultOptions = {
     importOrder: [],
-    importOrderBuiltinModulesToTop: false,
     importOrderCaseInsensitive: false,
     importOrderGroupNamespaceSpecifiers: false,
     importOrderMergeDuplicateImports: false,

--- a/src/utils/__tests__/remove-nodes-from-original-code.spec.ts
+++ b/src/utils/__tests__/remove-nodes-from-original-code.spec.ts
@@ -24,7 +24,6 @@ test('it should remove nodes from the original code', () => {
     const importNodes = getImportNodes(code);
     const sortedNodes = getSortedNodes(importNodes, {
         importOrder: [],
-        importOrderBuiltinModulesToTop: false,
         importOrderCaseInsensitive: false,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,

--- a/src/utils/get-sorted-nodes-by-import-order.ts
+++ b/src/utils/get-sorted-nodes-by-import-order.ts
@@ -26,7 +26,6 @@ export const getSortedNodesByImportOrder: GetSortedNodes = (nodes, options) => {
         importOrderSeparation,
         importOrderSortSpecifiers,
         importOrderGroupNamespaceSpecifiers,
-        importOrderBuiltinModulesToTop,
     } = options;
 
     const originalNodes = nodes.map(clone);
@@ -36,9 +35,8 @@ export const getSortedNodesByImportOrder: GetSortedNodes = (nodes, options) => {
         importOrder = [THIRD_PARTY_MODULES_SPECIAL_WORD, ...importOrder];
     }
 
-    if (importOrderBuiltinModulesToTop) {
-        importOrder = [BUILTIN_MODULES, ...importOrder];
-    }
+    // IDEA: We could make built-ins a special word, if people do not want them up top
+    importOrder = [BUILTIN_MODULES, ...importOrder];
 
     const importOrderGroups = importOrder.reduce<ImportGroups>(
         (groups, regexp) =>

--- a/src/utils/merge-nodes-with-matching-flavors.ts
+++ b/src/utils/merge-nodes-with-matching-flavors.ts
@@ -1,10 +1,11 @@
+import assert from 'assert';
+
 import type {
     ImportDeclaration,
     ImportDefaultSpecifier,
     ImportNamespaceSpecifier,
     ImportSpecifier,
 } from '@babel/types';
-import assert from 'assert';
 
 import {
     importFlavorType,

--- a/test-setup/run_spec.ts
+++ b/test-setup/run_spec.ts
@@ -2,6 +2,7 @@
 
 import fs from 'fs';
 import { extname, join, resolve } from 'path';
+
 import prettier from 'prettier';
 import { expect, test } from 'vitest';
 

--- a/tests/ImportOrderBuiltinModulesToTop/ppsi.spec.ts
+++ b/tests/ImportOrderBuiltinModulesToTop/ppsi.spec.ts
@@ -2,5 +2,4 @@ import {run_spec} from '../../test-setup/run_spec';
 
 run_spec(__dirname, ['typescript'], {
     importOrder: ['^[./]'],
-    importOrderBuiltinModulesToTop: true,
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -61,15 +61,6 @@ export interface PluginConfig {
     importOrderCaseInsensitive?: boolean;
 
     /**
-     * A boolean value to enable sorting of node builtins
-     * to the top of all import groups.
-     *
-     * @ref https://nodejs.org/api/module.html#modulebuiltinmodules
-     * @default false
-     */
-    importOrderBuiltinModulesToTop?: boolean;
-
-    /**
      * A boolean value to enable or disable sorting the namespace specifiers to the top of the import group.
      *
      * @default false


### PR DESCRIPTION
Reference: #22 

This is the first step towards removing some options from this plugin, to make it a bit more opinionated and easy to configure (and maintain). 

This PR removes the option for `importOrderBuiltinModulesToTop`, and instead sorts builtins to the top always.

We could potentially add a special flag for use in `importOrder` if someone wants to control the order of where the builtins appear, but I'd like to avoid doing that unless it becomes necessary.  