### PR TITLE
[Breaking] Remove importOrderCaseInsensitive option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Since then more critical features & fixes have been added. As a result, this rep
     - [`importOrder`](#importorder)
     - [`importOrderSortSpecifiers`](#importordersortspecifiers)
     - [`importOrderGroupNamespaceSpecifiers`](#importordergroupnamespacespecifiers)
-    - [`importOrderCaseInsensitive`](#importordercaseinsensitive)
     - [`importOrderMergeDuplicateImports`](#importordermergeduplicateimports)
     - [`importOrderCombineTypeAndValueImports`](#importordercombinetypeandvalueimports)
     - [`importOrderParserPlugins`](#importorderparserplugins)
@@ -129,7 +128,6 @@ module.exports = {
     singleQuote: true,
     semi: true,
     importOrder: ['^@core/(.*)$', '', '^@server/(.*)$', '', '^@ui/(.*)$', '', '^[./]'],
-    importOrderCaseInsensitive: true,
     importOrderParserPlugins: ['typescript', 'jsx', 'decorators-legacy'],
     importOrderMergeDuplicateImports: true,
     importOrderCombineTypeAndValueImports: true,
@@ -248,29 +246,6 @@ import Default, {charlie, delta as echo, type Alpha, type Bravo} from 'source';
 **default value:** `false`
 
 A boolean value to enable or disable sorting the namespace specifiers to the top of the import group.
-
-#### `importOrderCaseInsensitive`
-
-**type**: `boolean`
-
-**default value**: `false`
-
-A boolean value to enable case-insensitivity in the sorting algorithm
-used to order imports within each match group.
-
-For example, when false (or not specified):
-
-```javascript
-import ExampleView from './ExampleView';
-import ExamplesList from './ExamplesList';
-```
-
-compared with `"importOrderCaseInsensitive": true`:
-
-```javascript
-import ExamplesList from './ExamplesList';
-import ExampleView from './ExampleView';
-```
 
 #### `importOrderMergeDuplicateImports`
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -6,6 +6,7 @@
 
 - The `importOrderBuiltinModulesToTop` option has been removed, and node.js built in modules are always sorted to the top.
 - The `importOrderSeparation` option has been removed.  Use empty quotes in your `importOrder` to control the placement of blank lines.
+- The `importOrderCaseInsensitive` option has been removed, and imports will always be sorted case-insensitive.
 
 #### `importOrderSeparation` removed
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,12 +28,6 @@ export const options: Record<
         default: [{ value: [] }],
         description: 'Provide an order to sort imports.',
     },
-    importOrderCaseInsensitive: {
-        type: 'boolean',
-        category: 'Global',
-        default: false,
-        description: 'Provide a case sensitivity boolean flag',
-    },
     importOrderParserPlugins: {
         type: 'path',
         category: 'Global',

--- a/src/preprocessors/preprocessor.ts
+++ b/src/preprocessors/preprocessor.ts
@@ -1,4 +1,4 @@
-import { ParserOptions, parse as babelParser } from '@babel/parser';
+import { parse as babelParser, ParserOptions } from '@babel/parser';
 import traverse, { NodePath } from '@babel/traverse';
 import { ImportDeclaration, isTSModuleDeclaration } from '@babel/types';
 
@@ -12,7 +12,6 @@ export function preprocessor(code: string, options: PrettierOptions): string {
     const {
         importOrderParserPlugins,
         importOrder,
-        importOrderCaseInsensitive,
         importOrderGroupNamespaceSpecifiers,
         importOrderMergeDuplicateImports,
         importOrderSortSpecifiers,
@@ -68,7 +67,6 @@ export function preprocessor(code: string, options: PrettierOptions): string {
 
     const nodesToOutput = getSortedNodes(allOriginalImportNodes, {
         importOrder,
-        importOrderCaseInsensitive,
         importOrderGroupNamespaceSpecifiers,
         importOrderMergeDuplicateImports,
         importOrderCombineTypeAndValueImports,

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,6 @@ export type GetSortedNodes = (
     options: Pick<
         PrettierOptions,
         | 'importOrder'
-        | 'importOrderCaseInsensitive'
         | 'importOrderGroupNamespaceSpecifiers'
         | 'importOrderMergeDuplicateImports'
         | 'importOrderCombineTypeAndValueImports'

--- a/src/utils/__tests__/get-all-comments-from-nodes.spec.ts
+++ b/src/utils/__tests__/get-all-comments-from-nodes.spec.ts
@@ -11,7 +11,6 @@ const getSortedImportNodes = (code: string, options?: ParserOptions) => {
 
     return getSortedNodes(importNodes, {
         importOrder: [],
-        importOrderCaseInsensitive: false,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
         importOrderCombineTypeAndValueImports: false,

--- a/src/utils/__tests__/get-code-from-ast.spec.ts
+++ b/src/utils/__tests__/get-code-from-ast.spec.ts
@@ -18,7 +18,6 @@ import a from 'a';
     const importNodes = getImportNodes(code);
     const sortedNodes = getSortedNodes(importNodes, {
         importOrder: [],
-        importOrderCaseInsensitive: false,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
         importOrderCombineTypeAndValueImports: false,
@@ -58,7 +57,6 @@ import type {See} from 'c';
     const importNodes = getImportNodes(code, { plugins: ['typescript'] });
     const sortedNodes = getSortedNodes(importNodes, {
         importOrder: [],
-        importOrderCaseInsensitive: false,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: true,
         importOrderCombineTypeAndValueImports: false,

--- a/src/utils/__tests__/get-sorted-nodes-by-import-order.spec.ts
+++ b/src/utils/__tests__/get-sorted-nodes-by-import-order.spec.ts
@@ -29,7 +29,6 @@ test('it returns all sorted nodes', () => {
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^[./]'],
-        importOrderCaseInsensitive: false,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
         importOrderCombineTypeAndValueImports: false,
@@ -40,16 +39,16 @@ test('it returns all sorted nodes', () => {
         'node:fs/promises',
         'node:url',
         'path',
-        'BY',
-        'Ba',
-        'XY',
-        'Xa',
         'a',
+        'Ba',
+        'BY',
         'c',
         'g',
         'k',
         't',
         'x',
+        'Xa',
+        'XY',
         'z',
         './local',
     ]);
@@ -63,16 +62,16 @@ test('it returns all sorted nodes', () => {
         ['fs'],
         ['url'], // `node:url` comes before `path`
         ['path'],
-        ['BY'],
-        ['Ba'],
-        ['XY'],
-        ['Xa'],
         ['a'],
+        ['Ba'],
+        ['BY'],
         ['c', 'cD'],
         ['g'],
         ['k', 'kE', 'kB'],
         ['tC', 'tA', 'tB'],
         ['x'],
+        ['Xa'],
+        ['XY'],
         ['z'],
         ['local'],
     ]);
@@ -82,7 +81,6 @@ test('it returns all sorted nodes case-insensitive', () => {
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^[./]'],
-        importOrderCaseInsensitive: true,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
         importOrderCombineTypeAndValueImports: false,
@@ -135,28 +133,26 @@ test('it returns all sorted nodes with sort order', () => {
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^a$', '^t$', '^k$', '^B', '^[./]'],
-        importOrderCaseInsensitive: false,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
         importOrderCombineTypeAndValueImports: false,
         importOrderSortSpecifiers: false,
     }) as ImportDeclaration[];
-
     expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
         'node:fs/promises',
         'node:url',
         'path',
-        'XY',
-        'Xa',
         'c',
         'g',
         'x',
+        'Xa',
+        'XY',
         'z',
         'a',
         't',
         'k',
-        'BY',
         'Ba',
+        'BY',
         './local',
     ]);
     expect(
@@ -169,17 +165,17 @@ test('it returns all sorted nodes with sort order', () => {
         ['fs'],
         ['url'], // `node:url` comes before `path`
         ['path'],
-        ['XY'],
-        ['Xa'],
         ['c', 'cD'],
         ['g'],
         ['x'],
+        ['Xa'],
+        ['XY'],
         ['z'],
         ['a'],
         ['tC', 'tA', 'tB'],
         ['k', 'kE', 'kB'],
-        ['BY'],
         ['Ba'],
+        ['BY'],
         ['local'],
     ]);
 });
@@ -188,7 +184,6 @@ test('it returns all sorted nodes with sort order case-insensitive', () => {
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^a$', '^t$', '^k$', '^B', '^[./]'],
-        importOrderCaseInsensitive: true,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
         importOrderCombineTypeAndValueImports: false,
@@ -240,7 +235,6 @@ test('it returns all sorted import nodes with sorted import specifiers', () => {
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^a$', '^t$', '^k$', '^B', '^[./]'],
-        importOrderCaseInsensitive: false,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
         importOrderCombineTypeAndValueImports: false,
@@ -250,17 +244,17 @@ test('it returns all sorted import nodes with sorted import specifiers', () => {
         'node:fs/promises',
         'node:url',
         'path',
-        'XY',
-        'Xa',
         'c',
         'g',
         'x',
+        'Xa',
+        'XY',
         'z',
         'a',
         't',
         'k',
-        'BY',
         'Ba',
+        'BY',
         './local',
     ]);
     expect(
@@ -273,17 +267,17 @@ test('it returns all sorted import nodes with sorted import specifiers', () => {
         ['fs'],
         ['url'], // `node:url` comes before `path`
         ['path'],
-        ['XY'],
-        ['Xa'],
         ['c', 'cD'],
         ['g'],
         ['x'],
+        ['Xa'],
+        ['XY'],
         ['z'],
         ['a'],
         ['tA', 'tB', 'tC'],
         ['k', 'kB', 'kE'],
-        ['BY'],
         ['Ba'],
+        ['BY'],
         ['local'],
     ]);
 });
@@ -292,7 +286,6 @@ test('it returns all sorted import nodes with sorted import specifiers with case
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^a$', '^t$', '^k$', '^B', '^[./]'],
-        importOrderCaseInsensitive: true,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
         importOrderCombineTypeAndValueImports: false,
@@ -344,7 +337,6 @@ test('it returns all sorted nodes with namespace specifiers at the top (under bu
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^[./]'],
-        importOrderCaseInsensitive: false,
         importOrderGroupNamespaceSpecifiers: true,
         importOrderMergeDuplicateImports: false,
         importOrderCombineTypeAndValueImports: false,
@@ -357,24 +349,23 @@ test('it returns all sorted nodes with namespace specifiers at the top (under bu
         'path',
         'a',
         'x',
-        'BY',
         'Ba',
-        'XY',
-        'Xa',
+        'BY',
         'c',
         'g',
         'k',
         't',
+        'Xa',
+        'XY',
         'z',
         './local',
     ]);
 });
 
-test('it returns all sorted nodes with builtin specifiers at the top, ', () => {
+test('it returns all sorted nodes with builtin specifiers at the top', () => {
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^[./]'],
-        importOrderCaseInsensitive: false,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
         importOrderCombineTypeAndValueImports: false,
@@ -385,16 +376,16 @@ test('it returns all sorted nodes with builtin specifiers at the top, ', () => {
         'node:fs/promises',
         'node:url',
         'path',
-        'BY',
-        'Ba',
-        'XY',
-        'Xa',
         'a',
+        'Ba',
+        'BY',
         'c',
         'g',
         'k',
         't',
         'x',
+        'Xa',
+        'XY',
         'z',
         './local',
     ]);
@@ -404,7 +395,6 @@ test('it returns all sorted nodes with custom third party modules and builtins a
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^a$', '<THIRD_PARTY_MODULES>', '^t$', '^k$', '^[./]'],
-        importOrderCaseInsensitive: true,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
         importOrderCombineTypeAndValueImports: false,
@@ -440,7 +430,6 @@ test('it returns all sorted nodes with custom separation', () => {
             '^k$',
             '^[./]',
         ],
-        importOrderCaseInsensitive: true,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
         importOrderCombineTypeAndValueImports: false,
@@ -479,7 +468,6 @@ test('it does not add multiple custom import separators', () => {
             '^k$',
             '^[./]',
         ],
-        importOrderCaseInsensitive: true,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
         importOrderCombineTypeAndValueImports: false,

--- a/src/utils/__tests__/get-sorted-nodes.spec.ts
+++ b/src/utils/__tests__/get-sorted-nodes.spec.ts
@@ -30,13 +30,11 @@ test('it returns all sorted nodes, preserving the order side effect nodes', () =
     const result = getImportNodes(code);
     const sorted = getSortedNodes(result, {
         importOrder: [],
-        importOrderCaseInsensitive: false,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
         importOrderCombineTypeAndValueImports: false,
         importOrderSortSpecifiers: false,
     }) as ImportDeclaration[];
-
     expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
         'se3',
         'c',
@@ -47,12 +45,12 @@ test('it returns all sorted nodes, preserving the order side effect nodes', () =
         'se4',
         'se1',
         'path', // Builtins are not sorted past side-effects either
-        'BY',
-        'Ba',
-        'XY',
-        'Xa',
         'a',
+        'Ba',
+        'BY',
         'x',
+        'Xa',
+        'XY',
         'se2',
         '',
     ]);
@@ -72,12 +70,12 @@ test('it returns all sorted nodes, preserving the order side effect nodes', () =
         [],
         [],
         ['path'],
-        ['BY'],
-        ['Ba'],
-        ['XY'],
-        ['Xa'],
         ['a'],
+        ['Ba'],
+        ['BY'],
         ['x'],
+        ['Xa'],
+        ['XY'],
         [],
     ]);
 });

--- a/src/utils/__tests__/merge-nodes-with-matching-flavors.spec.ts
+++ b/src/utils/__tests__/merge-nodes-with-matching-flavors.spec.ts
@@ -7,7 +7,6 @@ import { getSortedNodes } from '../get-sorted-nodes';
 
 const defaultOptions = {
     importOrder: [''], // Separate side-effect and ignored chunks, for easier test readability
-    importOrderCaseInsensitive: false,
     importOrderGroupNamespaceSpecifiers: false,
     importOrderMergeDuplicateImports: false,
     importOrderCombineTypeAndValueImports: false,

--- a/src/utils/__tests__/remove-nodes-from-original-code.spec.ts
+++ b/src/utils/__tests__/remove-nodes-from-original-code.spec.ts
@@ -24,7 +24,6 @@ test('it should remove nodes from the original code', () => {
     const importNodes = getImportNodes(code);
     const sortedNodes = getSortedNodes(importNodes, {
         importOrder: [],
-        importOrderCaseInsensitive: false,
         importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
         importOrderCombineTypeAndValueImports: false,

--- a/src/utils/adjust-comments-on-sorted-nodes.ts
+++ b/src/utils/adjust-comments-on-sorted-nodes.ts
@@ -1,4 +1,4 @@
-import { ImportDeclaration, addComments, removeComments } from '@babel/types';
+import { addComments, ImportDeclaration, removeComments } from '@babel/types';
 import clone from 'lodash.clone';
 import isEqual from 'lodash.isequal';
 

--- a/src/utils/get-code-from-ast.ts
+++ b/src/utils/get-code-from-ast.ts
@@ -1,5 +1,5 @@
 import generate from '@babel/generator';
-import { Directive, InterpreterDirective, Statement, file } from '@babel/types';
+import { Directive, file, InterpreterDirective, Statement } from '@babel/types';
 
 import { newLineCharacters } from '../constants';
 import { getAllCommentsFromNodes } from './get-all-comments-from-nodes';

--- a/src/utils/get-import-nodes.ts
+++ b/src/utils/get-import-nodes.ts
@@ -1,4 +1,4 @@
-import { ParserOptions, parse as babelParser } from '@babel/parser';
+import { parse as babelParser, ParserOptions } from '@babel/parser';
 import traverse, { NodePath } from '@babel/traverse';
 import { ImportDeclaration, isTSModuleDeclaration } from '@babel/types';
 

--- a/src/utils/get-sorted-nodes-by-import-order.ts
+++ b/src/utils/get-sorted-nodes-by-import-order.ts
@@ -2,8 +2,8 @@ import clone from 'lodash.clone';
 
 import {
     BUILTIN_MODULES,
-    THIRD_PARTY_MODULES_SPECIAL_WORD,
     newLineNode,
+    THIRD_PARTY_MODULES_SPECIAL_WORD,
 } from '../constants';
 import { naturalSort } from '../natural-sort';
 import { GetSortedNodes, ImportGroups, ImportOrLine } from '../types';
@@ -19,7 +19,7 @@ import { getSortedNodesGroup } from './get-sorted-nodes-group';
  * @param options Options to influence the behavior of the sorting algorithm.
  */
 export const getSortedNodesByImportOrder: GetSortedNodes = (nodes, options) => {
-    naturalSort.insensitive = options.importOrderCaseInsensitive;
+    naturalSort.insensitive = true;
 
     let { importOrder } = options;
     const { importOrderSortSpecifiers, importOrderGroupNamespaceSpecifiers } =

--- a/src/utils/get-sorted-nodes.ts
+++ b/src/utils/get-sorted-nodes.ts
@@ -1,7 +1,7 @@
 import {
-    TYPES_SPECIAL_WORD,
     chunkTypeUnsortable,
     newLineNode,
+    TYPES_SPECIAL_WORD,
 } from '../constants';
 import { GetSortedNodes, ImportChunk, ImportOrLine } from '../types';
 import { adjustCommentsOnSortedNodes } from './adjust-comments-on-sorted-nodes';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -39,28 +39,6 @@ export interface PluginConfig {
     importOrder?: string[];
 
     /**
-     * A boolean value to enable case-insensitivity in the sorting algorithm
-     * used to order imports within each match group.
-     *
-     * For example, when false (or not specified):
-     *
-     * ```js
-     * import ExampleView from './ExampleView';
-     * import ExamplesList from './ExamplesList';
-     * ```
-     *
-     * compared with `"importOrderCaseInsensitive": true`:
-     *
-     * ```js
-     * import ExamplesList from './ExamplesList';
-     * import ExampleView from './ExampleView';
-     * ```
-     *
-     * @default false
-     */
-    importOrderCaseInsensitive?: boolean;
-
-    /**
      * A boolean value to enable or disable sorting the namespace specifiers to the top of the import group.
      *
      * @default false


### PR DESCRIPTION
Reference #22 

This removes the `importOrderCaseInsensitive` option, making sorts always case-insensitive.