### PR TITLE
[Breaking] Remove importOrderCaseInsensitive option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Since then more critical features & fixes have been added, and the options have 
   - [Options](#options)
     - [`importOrder`](#importorder)
     - [`importOrderSortSpecifiers`](#importordersortspecifiers)
-    - [`importOrderGroupNamespaceSpecifiers`](#importordergroupnamespacespecifiers)
     - [`importOrderMergeDuplicateImports`](#importordermergeduplicateimports)
     - [`importOrderCombineTypeAndValueImports`](#importordercombinetypeandvalueimports)
     - [`importOrderParserPlugins`](#importorderparserplugins)
@@ -241,14 +240,6 @@ After:
 ```ts
 import Default, {charlie, delta as echo, type Alpha, type Bravo} from 'source';
 ```
-
-#### `importOrderGroupNamespaceSpecifiers`
-
-**type**: `boolean`
-
-**default value:** `false`
-
-A boolean value to enable or disable sorting the namespace specifiers to the top of the import group.
 
 #### `importOrderMergeDuplicateImports`
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -7,6 +7,7 @@
 - The `importOrderBuiltinModulesToTop` option has been removed, and node.js built in modules are always sorted to the top.
 - The `importOrderSeparation` option has been removed.  Use empty quotes in your `importOrder` to control the placement of blank lines.
 - The `importOrderCaseInsensitive` option has been removed, and imports will always be sorted case-insensitive.
+- The `importOrderGroupNamespaceSpecifiers` option has been removed.
 
 #### `importOrderSeparation` removed
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,13 +37,6 @@ export const options: Record<
         default: [{ value: ['typescript', 'jsx'] }],
         description: 'Provide a list of plugins for special syntax',
     },
-    importOrderGroupNamespaceSpecifiers: {
-        type: 'boolean',
-        category: 'Global',
-        default: false,
-        description:
-            'Should namespace specifiers be grouped at the top of their group?',
-    },
     importOrderSortSpecifiers: {
         type: 'boolean',
         category: 'Global',

--- a/src/preprocessors/preprocessor.ts
+++ b/src/preprocessors/preprocessor.ts
@@ -12,7 +12,6 @@ export function preprocessor(code: string, options: PrettierOptions): string {
     const {
         importOrderParserPlugins,
         importOrder,
-        importOrderGroupNamespaceSpecifiers,
         importOrderMergeDuplicateImports,
         importOrderSortSpecifiers,
     } = options;
@@ -67,7 +66,6 @@ export function preprocessor(code: string, options: PrettierOptions): string {
 
     const nodesToOutput = getSortedNodes(allOriginalImportNodes, {
         importOrder,
-        importOrderGroupNamespaceSpecifiers,
         importOrderMergeDuplicateImports,
         importOrderCombineTypeAndValueImports,
         importOrderSortSpecifiers,

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,6 @@ export type GetSortedNodes = (
     options: Pick<
         PrettierOptions,
         | 'importOrder'
-        | 'importOrderGroupNamespaceSpecifiers'
         | 'importOrderMergeDuplicateImports'
         | 'importOrderCombineTypeAndValueImports'
         | 'importOrderSortSpecifiers'

--- a/src/utils/__tests__/get-all-comments-from-nodes.spec.ts
+++ b/src/utils/__tests__/get-all-comments-from-nodes.spec.ts
@@ -11,7 +11,6 @@ const getSortedImportNodes = (code: string, options?: ParserOptions) => {
 
     return getSortedNodes(importNodes, {
         importOrder: [],
-        importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
         importOrderCombineTypeAndValueImports: false,
         importOrderSortSpecifiers: false,

--- a/src/utils/__tests__/get-code-from-ast.spec.ts
+++ b/src/utils/__tests__/get-code-from-ast.spec.ts
@@ -18,7 +18,6 @@ import a from 'a';
     const importNodes = getImportNodes(code);
     const sortedNodes = getSortedNodes(importNodes, {
         importOrder: [],
-        importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
         importOrderCombineTypeAndValueImports: false,
         importOrderSortSpecifiers: false,
@@ -57,7 +56,6 @@ import type {See} from 'c';
     const importNodes = getImportNodes(code, { plugins: ['typescript'] });
     const sortedNodes = getSortedNodes(importNodes, {
         importOrder: [],
-        importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: true,
         importOrderCombineTypeAndValueImports: false,
         importOrderSortSpecifiers: false,

--- a/src/utils/__tests__/get-sorted-nodes-by-import-order.spec.ts
+++ b/src/utils/__tests__/get-sorted-nodes-by-import-order.spec.ts
@@ -29,7 +29,6 @@ test('it returns all sorted nodes', () => {
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^[./]'],
-        importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
         importOrderCombineTypeAndValueImports: false,
         importOrderSortSpecifiers: false,
@@ -81,7 +80,6 @@ test('it returns all sorted nodes case-insensitive', () => {
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^[./]'],
-        importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
         importOrderCombineTypeAndValueImports: false,
         importOrderSortSpecifiers: false,
@@ -133,7 +131,6 @@ test('it returns all sorted nodes with sort order', () => {
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^a$', '^t$', '^k$', '^B', '^[./]'],
-        importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
         importOrderCombineTypeAndValueImports: false,
         importOrderSortSpecifiers: false,
@@ -184,7 +181,6 @@ test('it returns all sorted nodes with sort order case-insensitive', () => {
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^a$', '^t$', '^k$', '^B', '^[./]'],
-        importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
         importOrderCombineTypeAndValueImports: false,
         importOrderSortSpecifiers: false,
@@ -235,7 +231,6 @@ test('it returns all sorted import nodes with sorted import specifiers', () => {
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^a$', '^t$', '^k$', '^B', '^[./]'],
-        importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
         importOrderCombineTypeAndValueImports: false,
         importOrderSortSpecifiers: true,
@@ -286,7 +281,6 @@ test('it returns all sorted import nodes with sorted import specifiers with case
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^a$', '^t$', '^k$', '^B', '^[./]'],
-        importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
         importOrderCombineTypeAndValueImports: false,
         importOrderSortSpecifiers: true,
@@ -333,40 +327,10 @@ test('it returns all sorted import nodes with sorted import specifiers with case
     ]);
 });
 
-test('it returns all sorted nodes with namespace specifiers at the top (under builtins)', () => {
-    const result = getImportNodes(code);
-    const sorted = getSortedNodesByImportOrder(result, {
-        importOrder: ['^[./]'],
-        importOrderGroupNamespaceSpecifiers: true,
-        importOrderMergeDuplicateImports: false,
-        importOrderCombineTypeAndValueImports: false,
-        importOrderSortSpecifiers: false,
-    }) as ImportDeclaration[];
-
-    expect(getSortedNodesNamesAndNewlines(sorted)).toEqual([
-        'node:fs/promises',
-        'node:url',
-        'path',
-        'a',
-        'x',
-        'Ba',
-        'BY',
-        'c',
-        'g',
-        'k',
-        't',
-        'Xa',
-        'XY',
-        'z',
-        './local',
-    ]);
-});
-
 test('it returns all sorted nodes with builtin specifiers at the top', () => {
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^[./]'],
-        importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
         importOrderCombineTypeAndValueImports: false,
         importOrderSortSpecifiers: false,
@@ -395,7 +359,6 @@ test('it returns all sorted nodes with custom third party modules and builtins a
     const result = getImportNodes(code);
     const sorted = getSortedNodesByImportOrder(result, {
         importOrder: ['^a$', '<THIRD_PARTY_MODULES>', '^t$', '^k$', '^[./]'],
-        importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
         importOrderCombineTypeAndValueImports: false,
         importOrderSortSpecifiers: false,
@@ -430,7 +393,6 @@ test('it returns all sorted nodes with custom separation', () => {
             '^k$',
             '^[./]',
         ],
-        importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
         importOrderCombineTypeAndValueImports: false,
         importOrderSortSpecifiers: false,
@@ -468,7 +430,6 @@ test('it does not add multiple custom import separators', () => {
             '^k$',
             '^[./]',
         ],
-        importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
         importOrderCombineTypeAndValueImports: false,
         importOrderSortSpecifiers: false,

--- a/src/utils/__tests__/get-sorted-nodes.spec.ts
+++ b/src/utils/__tests__/get-sorted-nodes.spec.ts
@@ -30,7 +30,6 @@ test('it returns all sorted nodes, preserving the order side effect nodes', () =
     const result = getImportNodes(code);
     const sorted = getSortedNodes(result, {
         importOrder: [],
-        importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
         importOrderCombineTypeAndValueImports: false,
         importOrderSortSpecifiers: false,

--- a/src/utils/__tests__/merge-nodes-with-matching-flavors.spec.ts
+++ b/src/utils/__tests__/merge-nodes-with-matching-flavors.spec.ts
@@ -7,7 +7,6 @@ import { getSortedNodes } from '../get-sorted-nodes';
 
 const defaultOptions = {
     importOrder: [''], // Separate side-effect and ignored chunks, for easier test readability
-    importOrderGroupNamespaceSpecifiers: false,
     importOrderMergeDuplicateImports: false,
     importOrderCombineTypeAndValueImports: false,
     importOrderSortSpecifiers: true,

--- a/src/utils/__tests__/remove-nodes-from-original-code.spec.ts
+++ b/src/utils/__tests__/remove-nodes-from-original-code.spec.ts
@@ -24,7 +24,6 @@ test('it should remove nodes from the original code', () => {
     const importNodes = getImportNodes(code);
     const sortedNodes = getSortedNodes(importNodes, {
         importOrder: [],
-        importOrderGroupNamespaceSpecifiers: false,
         importOrderMergeDuplicateImports: false,
         importOrderCombineTypeAndValueImports: false,
         importOrderSortSpecifiers: false,

--- a/src/utils/get-sorted-nodes-by-import-order.ts
+++ b/src/utils/get-sorted-nodes-by-import-order.ts
@@ -22,8 +22,7 @@ export const getSortedNodesByImportOrder: GetSortedNodes = (nodes, options) => {
     naturalSort.insensitive = true;
 
     let { importOrder } = options;
-    const { importOrderSortSpecifiers, importOrderGroupNamespaceSpecifiers } =
-        options;
+    const { importOrderSortSpecifiers } = options;
 
     const originalNodes = nodes.map(clone);
     const finalNodes: ImportOrLine[] = [];
@@ -82,9 +81,7 @@ export const getSortedNodesByImportOrder: GetSortedNodes = (nodes, options) => {
 
         if (groupNodes.length === 0) continue;
 
-        const sortedInsideGroup = getSortedNodesGroup(groupNodes, {
-            importOrderGroupNamespaceSpecifiers,
-        });
+        const sortedInsideGroup = getSortedNodesGroup(groupNodes);
 
         // Sort the import specifiers
         if (importOrderSortSpecifiers) {

--- a/src/utils/get-sorted-nodes-group.ts
+++ b/src/utils/get-sorted-nodes-group.ts
@@ -1,32 +1,7 @@
-import { Import, ImportDeclaration } from '@babel/types';
+import { ImportDeclaration } from '@babel/types';
 
 import { naturalSort } from '../natural-sort';
-import { PrettierOptions } from '../types';
 
-export const getSortedNodesGroup = (
-    imports: ImportDeclaration[],
-    options: Pick<PrettierOptions, 'importOrderGroupNamespaceSpecifiers'>,
-) => {
-    return imports.sort((a, b) => {
-        if (options.importOrderGroupNamespaceSpecifiers) {
-            const diff = namespaceSpecifierSort(a, b);
-            if (diff !== 0) return diff;
-        }
-
-        return naturalSort(a.source.value, b.source.value);
-    });
+export const getSortedNodesGroup = (imports: ImportDeclaration[]) => {
+    return imports.sort((a, b) => naturalSort(a.source.value, b.source.value));
 };
-
-function namespaceSpecifierSort(a: ImportDeclaration, b: ImportDeclaration) {
-    const aFirstSpecifier = a.specifiers.find(
-        (s) => s.type === 'ImportNamespaceSpecifier',
-    )
-        ? 1
-        : 0;
-    const bFirstSpecifier = b.specifiers.find(
-        (s) => s.type === 'ImportNamespaceSpecifier',
-    )
-        ? 1
-        : 0;
-    return bFirstSpecifier - aFirstSpecifier;
-}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -39,13 +39,6 @@ export interface PluginConfig {
     importOrder?: string[];
 
     /**
-     * A boolean value to enable or disable sorting the namespace specifiers to the top of the import group.
-     *
-     * @default false
-     */
-    importOrderGroupNamespaceSpecifiers?: boolean;
-
-    /**
      * When `true`, multiple import statements from the same module will be combined into a single import.
      *
      * @default false


### PR DESCRIPTION
Ref #22 

This removes the `importOrderGroupNamespaceSpecifiers` option in an effort to simplify the plugin and make it easier to understand and set up.  There's no replacement currently, but if we hear from lots of folks who really want this, I think we could re-implement it using a special term in `importOrder`.  I haven't done that here, as I would prefer to keep it simple.