### PR TITLE
Fix behavior around comments embedded in imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: ${{ matrix.node }}
-                  cache: 'yarn'
-                  cache-dependency-path: 'yarn.lock'
+                  #   cache: 'yarn'
+                  #   cache-dependency-path: 'yarn.lock' # Something weird was happening?
             - run: yarn install --frozen-lockfile --non-interactive
             - name: Test
               run: yarn test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: ${{ matrix.node }}
-                  #   cache: 'yarn'
-                  #   cache-dependency-path: 'yarn.lock' # Something weird was happening?
+                  cache: 'yarn'
+                  cache-dependency-path: 'yarn.lock'
             - run: yarn install --frozen-lockfile --non-interactive
             - name: Test
               run: yarn test

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Since then more critical features & fixes have been added, and the options have 
     - [`importOrderTypeScriptVersion`](#importordertypescriptversion)
     - [`importOrderParserPlugins`](#importorderparserplugins)
   - [Prevent imports from being sorted](#prevent-imports-from-being-sorted)
+  - [Comments](#comments)
 - [FAQ / Troubleshooting](#faq--troubleshooting)
 - [Compatibility](#compatibility)
 - [Contribution](#contribution)
@@ -271,16 +272,14 @@ This will keep the `zealand` import at the top instead of moving it below the `a
 entire import statements can be ignored, line comments (`// prettier-ignore`) are recommended over inline comments
 (`/* prettier-ignore */`).
 
-### Commented Lines inside of Imports
+### Comments
 
-We make the following attempts at keeping comments in your imports clean, but there's some pain points when imports are shuffled.
+We make the following attempts at keeping comments in your imports clean:
 
-Specific cases we handle:
-
-- If you have one or more comments that end above the line immediately preceding your first import, we will treat them as top-of-file comment(s) and avoid moving them when the first-import moves down.
-- If you have comments that come after after your last import; those comments and following code will stay below the imports. (Runtime-code between imports will be moved below all the imports)
-- In general, if you place a single-line comment on the same line as an Import `Declaration` or `*Specifier`, we will keep it attached to that same specifier if that line moves around (due to mergers, or sorting changes due to newly inserted imports).
-- Other comments are preserved, and are generally considered `leadingComments` for the subsequent Import `Declaration` or `*Specifier`
+- If you have one or more comments at the top of the file, we will keep them at the top as long as there is a blank line before your first import statement.
+- Comments on lines after the final import statement will not be moved. (Runtime-code between imports will be moved below all the imports).
+- In general, if you place a comment on the same line as an Import `Declaration` or `*Specifier`, we will keep it attached to that same specifier if it moves around.
+- Other comments are preserved, and are generally considered "leading" comments for the subsequent Import `Declaration` or `*Specifier`.
 
 ## FAQ / Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -271,6 +271,18 @@ This will keep the `zealand` import at the top instead of moving it below the `a
 entire import statements can be ignored, line comments (`// prettier-ignore`) are recommended over inline comments
 (`/* prettier-ignore */`).
 
+### Commented Lines inside of Imports
+
+We make the following attempts at keeping comments in your imports clean, but there's some pain points when imports are shuffled.
+
+Specific cases we handle:
+
+- If you leave a gap after a comment at the top of your file, we will avoid moving it around if the imports below it shift.
+- If you have comments that come after after your last import (with a gap); that comment and following code will stay below the imports.
+- In general, if you place a single-line `CommentLine` (eg. `// …`) on the same line as an `ImportDeclaration` or `ImportSpecifier`, we will keep it attached to that same specifier if that line moves around (due to mergers, or sorting changes due to newly inserted imports).
+- Multi-line-capable `CommentBlocks` (eg. `/** … */`) are automatically formatted to be on a new line by Prettier, so we do not change this behavior.
+- Other comments are preserved, and are generally considered `leadingComments` for the subsequent `ImportDeclaration` or `ImportSpecifier`
+
 ## FAQ / Troubleshooting
 
 Having some trouble or an issue? You can check [FAQ / Troubleshooting section](./docs/TROUBLESHOOTING.md).

--- a/README.md
+++ b/README.md
@@ -279,9 +279,8 @@ Specific cases we handle:
 
 - If you leave a gap after a comment at the top of your file, we will avoid moving it around if the imports below it shift.
 - If you have comments that come after after your last import (with a gap); that comment and following code will stay below the imports.
-- In general, if you place a single-line `CommentLine` (eg. `// …`) on the same line as an `ImportDeclaration` or `ImportSpecifier`, we will keep it attached to that same specifier if that line moves around (due to mergers, or sorting changes due to newly inserted imports).
-- Multi-line-capable `CommentBlocks` (eg. `/** … */`) are automatically formatted to be on a new line by Prettier, so we do not change this behavior.
-- Other comments are preserved, and are generally considered `leadingComments` for the subsequent `ImportDeclaration` or `ImportSpecifier`
+- In general, if you place a single-line comment on the same line as an Import `Declaration` or `*Specifier`, we will keep it attached to that same specifier if that line moves around (due to mergers, or sorting changes due to newly inserted imports).
+- Other comments are preserved, and are generally considered `leadingComments` for the subsequent Import `Declaration` or `*Specifier`
 
 ## FAQ / Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -277,8 +277,8 @@ We make the following attempts at keeping comments in your imports clean, but th
 
 Specific cases we handle:
 
-- If you leave a gap after a comment at the top of your file, we will avoid moving it around if the imports below it shift.
-- If you have comments that come after after your last import (with a gap); that comment and following code will stay below the imports.
+- If you have one or more comments that end above the line immediately preceding your first import, we will treat them as top-of-file comment(s) and avoid moving them when the first-import moves down.
+- If you have comments that come after after your last import; those comments and following code will stay below the imports. (Runtime-code between imports will be moved below all the imports)
 - In general, if you place a single-line comment on the same line as an Import `Declaration` or `*Specifier`, we will keep it attached to that same specifier if that line moves around (due to mergers, or sorting changes due to newly inserted imports).
 - Other comments are preserved, and are generally considered `leadingComments` for the subsequent Import `Declaration` or `*Specifier`
 

--- a/package.json
+++ b/package.json
@@ -58,14 +58,12 @@
         "@babel/traverse": "^7.17.3",
         "@babel/types": "^7.17.0",
         "lodash.clone": "^4.5.0",
-        "lodash.isequal": "^4.5.0",
         "semver": "^7.5.0"
     },
     "devDependencies": {
         "@types/babel__generator": "^7.6.4",
         "@types/babel__traverse": "^7.18.3",
         "@types/lodash.clone": "4.5.7",
-        "@types/lodash.isequal": "4.5.6",
         "@types/node": "^18.15.13",
         "@types/prettier": "^2.7.2",
         "@types/semver": "^7.3.13",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -37,3 +37,23 @@ const PRETTIER_PLUGIN_SORT_IMPORTS_NEW_LINE =
 export const newLineNode = expressionStatement(
     stringLiteral(PRETTIER_PLUGIN_SORT_IMPORTS_NEW_LINE),
 );
+export const injectNewlinesRegex = /"PRETTIER_PLUGIN_SORT_IMPORTS_NEW_LINE";/gi;
+
+/**
+ * If you have a trailing single-line comment on an ImportSpecifier, and attached to
+ *  the following ImportSpecifier you have a leading single-line comment,
+ * Then Babel's code-generator might render the two comments on the same line.
+ *
+ * This probably should be reported upstream, but for now we have a workaround.
+ */
+export const PATCH_BABEL_GENERATOR_DOUBLE_COMMENTS_ON_ONE_LINE_ISSUE = true;
+
+export const forceANewlineForImportSpecifiersWithLeadingComments = () => ({
+    type: 'CommentLine' as const,
+    value: 'PRETTIER_PLUGIN_SORT_IMPORTS_SPECIFIER_LEADING_COMMENT_PATCH',
+    start: -1,
+    end: -1,
+    loc: { start: { line: -1, column: -1 }, end: { line: -1, column: -1 } },
+});
+export const forceANewlineForImportSpecifiersWithLeadingCommentsRegex =
+    /\/\/PRETTIER_PLUGIN_SORT_IMPORTS_SPECIFIER_LEADING_COMMENT_PATCH/gi;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -34,29 +34,18 @@ export const TYPES_SPECIAL_WORD = '<TYPES>';
 const PRETTIER_PLUGIN_SORT_IMPORTS_NEW_LINE =
     'PRETTIER_PLUGIN_SORT_IMPORTS_NEW_LINE';
 
+/** Use this to force a newline at top-level scope (good for newlines generated between import blocks) */
 export const newLineNode = expressionStatement(
     stringLiteral(PRETTIER_PLUGIN_SORT_IMPORTS_NEW_LINE),
 );
-export const injectNewlinesRegex = /"PRETTIER_PLUGIN_SORT_IMPORTS_NEW_LINE";/gi;
-
-/**
- * If you have a trailing single-line comment on an ImportSpecifier, and attached to
- *  the following ImportSpecifier you have a leading single-line comment,
- * Then Babel's code-generator might render the two comments on the same line.
- *
- * Additionally, if you have a single-line-comment trailing an ImportDeclaration,
- *  babel might pull
- *
- * This probably should be reported upstream, but for now we have a workaround.
- */
-export const PATCH_BABEL_GENERATOR_DOUBLE_COMMENTS_ON_ONE_LINE_ISSUE = true;
-
-export const forceANewlineForImportsWithAttachedSingleLineComments = () => ({
+/** Use this if you want to force a newline, but you're attaching to leading/inner/trailing Comments */
+export const forceANewlineUsingACommentStatement = () => ({
     type: 'CommentLine' as const,
-    value: 'PRETTIER_PLUGIN_SORT_IMPORTS_SINGLE_LINE_COMMENTS_PATCH',
+    value: 'PRETTIER_PLUGIN_SORT_IMPORTS_NEWLINE_COMMENT',
     start: -1,
     end: -1,
     loc: { start: { line: -1, column: -1 }, end: { line: -1, column: -1 } },
 });
-export const forceANewlineForImportsWithAttachedSingleLineCommentsRegex =
-    /\/\/PRETTIER_PLUGIN_SORT_IMPORTS_SINGLE_LINE_COMMENTS_PATCH/gi;
+
+export const injectNewlinesRegex =
+    /("PRETTIER_PLUGIN_SORT_IMPORTS_NEW_LINE";|\/\/PRETTIER_PLUGIN_SORT_IMPORTS_NEWLINE_COMMENT)/gi;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -44,16 +44,19 @@ export const injectNewlinesRegex = /"PRETTIER_PLUGIN_SORT_IMPORTS_NEW_LINE";/gi;
  *  the following ImportSpecifier you have a leading single-line comment,
  * Then Babel's code-generator might render the two comments on the same line.
  *
+ * Additionally, if you have a single-line-comment trailing an ImportDeclaration,
+ *  babel might pull
+ *
  * This probably should be reported upstream, but for now we have a workaround.
  */
 export const PATCH_BABEL_GENERATOR_DOUBLE_COMMENTS_ON_ONE_LINE_ISSUE = true;
 
-export const forceANewlineForImportSpecifiersWithLeadingComments = () => ({
+export const forceANewlineForImportsWithAttachedSingleLineComments = () => ({
     type: 'CommentLine' as const,
-    value: 'PRETTIER_PLUGIN_SORT_IMPORTS_SPECIFIER_LEADING_COMMENT_PATCH',
+    value: 'PRETTIER_PLUGIN_SORT_IMPORTS_SINGLE_LINE_COMMENTS_PATCH',
     start: -1,
     end: -1,
     loc: { start: { line: -1, column: -1 }, end: { line: -1, column: -1 } },
 });
-export const forceANewlineForImportSpecifiersWithLeadingCommentsRegex =
-    /\/\/PRETTIER_PLUGIN_SORT_IMPORTS_SPECIFIER_LEADING_COMMENT_PATCH/gi;
+export const forceANewlineForImportsWithAttachedSingleLineCommentsRegex =
+    /\/\/PRETTIER_PLUGIN_SORT_IMPORTS_SINGLE_LINE_COMMENTS_PATCH/gi;

--- a/src/preprocessors/preprocessor.ts
+++ b/src/preprocessors/preprocessor.ts
@@ -31,6 +31,7 @@ export function preprocessor(code: string, options: PrettierOptions): string {
     const allOriginalImportNodes: ImportDeclaration[] = [];
     const parserOptions: ParserOptions = {
         sourceType: 'module',
+        attachComment: true,
         plugins: getExperimentalParserPlugins(importOrderParserPlugins),
     };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,9 @@
-import { ExpressionStatement, ImportDeclaration } from '@babel/types';
+import {
+    EmptyStatement,
+    ExpressionStatement,
+    ImportDeclaration,
+    ImportSpecifier,
+} from '@babel/types';
 import { RequiredOptions } from 'prettier';
 
 import { PluginConfig } from '../types';
@@ -28,7 +33,10 @@ export interface ImportChunk {
 }
 
 export type ImportGroups = Record<string, ImportDeclaration[]>;
-export type ImportOrLine = ImportDeclaration | ExpressionStatement;
+export type ImportOrLine =
+    | ImportDeclaration
+    | ExpressionStatement
+    | EmptyStatement;
 
 export type GetSortedNodes = (
     nodes: ImportDeclaration[],

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,10 @@
 import {
-    EmptyStatement,
-    ExpressionStatement,
-    ImportDeclaration,
-    ImportSpecifier,
+    type EmptyStatement,
+    type ExpressionStatement,
+    type ImportDeclaration,
+    type ImportDefaultSpecifier,
+    type ImportNamespaceSpecifier,
+    type ImportSpecifier,
 } from '@babel/types';
 import { RequiredOptions } from 'prettier';
 
@@ -37,6 +39,12 @@ export type ImportOrLine =
     | ImportDeclaration
     | ExpressionStatement
     | EmptyStatement;
+
+export type SomeSpecifier =
+    | ImportSpecifier
+    | ImportDefaultSpecifier
+    | ImportNamespaceSpecifier;
+export type ImportRelated = ImportOrLine | SomeSpecifier;
 
 export type GetSortedNodes = (
     nodes: ImportDeclaration[],

--- a/src/utils/__tests__/adjust-comments-on-sorted-nodes.spec.ts
+++ b/src/utils/__tests__/adjust-comments-on-sorted-nodes.spec.ts
@@ -1,6 +1,5 @@
 import { expect, test } from 'vitest';
 
-import { PATCH_BABEL_GENERATOR_DOUBLE_COMMENTS_ON_ONE_LINE_ISSUE } from '../../constants';
 import type { ImportOrLine } from '../../types';
 import { adjustCommentsOnSortedNodes } from '../adjust-comments-on-sorted-nodes';
 import { getImportNodes } from '../get-import-nodes';
@@ -104,11 +103,6 @@ test('it does not affect comments after all import declarations', () => {
     // "final 1" is attached as a trailing-comment for import from "a"
     // but "final 2" is detached so it stays with the bottom-of-imports
     const expectedNode1TrailingComments = [' comment final 1'];
-    if (PATCH_BABEL_GENERATOR_DOUBLE_COMMENTS_ON_ONE_LINE_ISSUE) {
-        expectedNode1TrailingComments.unshift(
-            'PRETTIER_PLUGIN_SORT_IMPORTS_SINGLE_LINE_COMMENTS_PATCH',
-        );
-    }
     expect(trailingComments(adjustedNodes[1])).toEqual(
         expectedNode1TrailingComments,
     );

--- a/src/utils/__tests__/adjust-comments-on-sorted-nodes.spec.ts
+++ b/src/utils/__tests__/adjust-comments-on-sorted-nodes.spec.ts
@@ -24,10 +24,15 @@ test('it preserves the single leading comment for each import declaration', () =
     const finalNodes = [importNodes[2], importNodes[1], importNodes[0]];
     const adjustedNodes = adjustCommentsOnSortedNodes(importNodes, finalNodes);
     expect(adjustedNodes).toHaveLength(4);
+    // First node is a dummy EmptyStatement
+    expect(adjustedNodes[0].type).toEqual('EmptyStatement');
+    expect(leadingComments(adjustedNodes[0])).toEqual([]);
+    expect(trailingComments(adjustedNodes[0])).toEqual([]);
     expect(leadingComments(adjustedNodes[1])).toEqual([' comment a']);
     expect(trailingComments(adjustedNodes[1])).toEqual([]);
     expect(leadingComments(adjustedNodes[2])).toEqual([' comment b']);
     expect(trailingComments(adjustedNodes[2])).toEqual([]);
+    // Import from "c" has no leading comment, and the trailing was kept with "b"
     expect(leadingComments(adjustedNodes[3])).toEqual([]);
     expect(trailingComments(adjustedNodes[3])).toEqual([]);
 });
@@ -64,7 +69,7 @@ test('it preserves multiple leading comments for each import declaration', () =>
     expect(trailingComments(adjustedNodes[3])).toEqual([]);
 });
 
-test('it does not move comments at before all import declarations', () => {
+test('it does not move comments more than one line before all import declarations', () => {
     const importNodes = getImportNodes(`
     // comment c1
     // comment c2
@@ -76,7 +81,7 @@ test('it does not move comments at before all import declarations', () => {
     const finalNodes = [importNodes[2], importNodes[1], importNodes[0]];
     const adjustedNodes = adjustCommentsOnSortedNodes(importNodes, finalNodes);
     expect(adjustedNodes).toHaveLength(4);
-    // Comment c1 is explicitly detached so it stays with the top-of-file
+    // Comment c1 is more than one line above the first import, so it stays with the top-of-file
     expect(leadingComments(adjustedNodes[0])).toEqual([' comment c1']);
 
     expect(leadingComments(adjustedNodes[2])).toEqual([]);

--- a/src/utils/__tests__/adjust-comments-on-sorted-nodes.spec.ts
+++ b/src/utils/__tests__/adjust-comments-on-sorted-nodes.spec.ts
@@ -100,12 +100,7 @@ test('it does not affect comments after all import declarations', () => {
     const adjustedNodes = adjustCommentsOnSortedNodes(importNodes, finalNodes);
     expect(adjustedNodes).toHaveLength(4);
     expect(leadingComments(adjustedNodes[1])).toEqual([]);
-    // "final 1" is attached as a trailing-comment for import from "a"
-    // but "final 2" is detached so it stays with the bottom-of-imports
-    const expectedNode1TrailingComments = [' comment final 1'];
-    expect(trailingComments(adjustedNodes[1])).toEqual(
-        expectedNode1TrailingComments,
-    );
+    expect(trailingComments(adjustedNodes[1])).toEqual([]);
     expect(leadingComments(adjustedNodes[2])).toEqual([]);
     expect(trailingComments(adjustedNodes[2])).toEqual([]);
     expect(leadingComments(adjustedNodes[3])).toEqual([]);

--- a/src/utils/__tests__/get-code-from-ast.spec.ts
+++ b/src/utils/__tests__/get-code-from-ast.spec.ts
@@ -6,9 +6,7 @@ import { getImportNodes } from '../get-import-nodes';
 import { getSortedNodes } from '../get-sorted-nodes';
 
 test('sorts imports correctly', () => {
-    const code = `// first comment
-// second comment
-import z from 'z';
+    const code = `import z from 'z';
 import c from 'c';
 import g from 'g';
 import t from 't';
@@ -26,9 +24,7 @@ import a from 'a';
         directives: [],
     });
     expect(format(formatted, { parser: 'babel' })).toEqual(
-        `// first comment
-// second comment
-import a from "a";
+        `import a from "a";
 import c from "c";
 import g from "g";
 import k from "k";
@@ -39,9 +35,7 @@ import z from "z";
 });
 
 test('merges duplicate imports correctly', () => {
-    const code = `// first comment
-// second comment
-import z from 'z';
+    const code = `import z from 'z';
 import c from 'c';
 import g from 'g';
 import t from 't';
@@ -63,9 +57,7 @@ import type {See} from 'c';
         directives: [],
     });
     expect(format(formatted, { parser: 'babel' })).toEqual(
-        `// first comment
-// second comment
-import a, { b, type Bee } from "a";
+        `import a, { b, type Bee } from "a";
 import c, { type C, type See } from "c";
 import g from "g";
 import k from "k";

--- a/src/utils/__tests__/get-sorted-nodes.spec.ts
+++ b/src/utils/__tests__/get-sorted-nodes.spec.ts
@@ -6,8 +6,7 @@ import { getSortedNodes } from '../get-sorted-nodes';
 import { getSortedNodesModulesNames } from '../get-sorted-nodes-modules-names';
 import { getSortedNodesNamesAndNewlines } from '../get-sorted-nodes-names-and-newlines';
 
-const code = `// first comment
-// second comment
+const code = `
 import "se3";
 import z from 'z';
 import c, { cD } from 'c';

--- a/src/utils/__tests__/get-sorted-nodes.spec.ts
+++ b/src/utils/__tests__/get-sorted-nodes.spec.ts
@@ -50,13 +50,14 @@ test('it returns all sorted nodes, preserving the order side effect nodes', () =
         'se2',
         '',
     ]);
-    expect(
-        sorted
-            .filter((node) => node.type === 'ImportDeclaration')
-            .map((importDeclaration) =>
-                getSortedNodesModulesNames(importDeclaration.specifiers),
-            ),
-    ).toEqual([
+
+    const result2 = sorted
+        .filter((node) => node.type === 'ImportDeclaration')
+        .map((importDeclaration) =>
+            getSortedNodesModulesNames(importDeclaration.specifiers),
+        );
+
+    expect(result2).toEqual([
         [],
         ['c', 'cD'],
         ['g'],

--- a/src/utils/adjust-comments-on-sorted-nodes.ts
+++ b/src/utils/adjust-comments-on-sorted-nodes.ts
@@ -3,41 +3,50 @@ import {
     removeComments,
     type ImportDeclaration,
 } from '@babel/types';
-import clone from 'lodash.clone';
-import isEqual from 'lodash.isequal';
 
 import { ImportOrLine } from '../types';
+import {
+    attachCommentsToOutputNodes,
+    getCommentRegistryFromImportDeclarations,
+} from './get-comment-registry';
 
 /**
  * Takes the original nodes before sorting and the final nodes after sorting.
  * Adjusts the comments on the final nodes so that they match the comments as
  * they were in the original nodes.
- * @param nodes A list of nodes in the order as they were originally.
+ * @param originalDeclarationNodes A list of nodes in the order as they were originally.
  * @param finalNodes The same set of nodes, but in the final sorting order.
  * @returns A copied and adjusted set of nodes, containing comments
  */
 export const adjustCommentsOnSortedNodes = (
-    nodes: ImportDeclaration[],
+    originalDeclarationNodes: ImportDeclaration[],
     finalNodes: ImportOrLine[],
 ) => {
-    // We will mutate a copy of the finalNodes, and extract comments from the original
-    const finalNodesClone = finalNodes.map(clone);
 
-    const firstNodesComments = nodes[0].leadingComments;
+    const outputDeclarationNodes: ImportDeclaration[] = finalNodes.filter(
+        (n) => n.type === 'ImportDeclaration',
+    ) as ImportDeclaration[];
 
-    // Remove all comments from sorted nodes
-    finalNodesClone.forEach(removeComments);
+    const registry = getCommentRegistryFromImportDeclarations(
+        outputDeclarationNodes,
+        originalDeclarationNodes[0],
+    );
 
-    // insert comments other than the first comments
-    finalNodesClone.forEach((node, index) => {
-        if (isEqual(nodes[0].loc, node.loc)) return;
+    // Make a copy of the nodes for easier debugging & remove the existing comments to reattach them
+    // (removeComments clones the nodes internally, so we don't need to do that ourselves)
+    const finalNodesClone = finalNodes.map((n) => {
+        const noDirectCommentsNode = removeComments(n);
+        if (noDirectCommentsNode.type === 'ImportDeclaration') {
+            // Remove comments isn't recursive, so we need to clone/modify the specifiers manually
+            noDirectCommentsNode.specifiers = (
+                noDirectCommentsNode.specifiers || []
+            ).map((s) => removeComments(s));
+        }
+        return noDirectCommentsNode;
 
-        addComments(node, 'leading', finalNodes[index].leadingComments || []);
     });
 
-    if (firstNodesComments) {
-        addComments(finalNodesClone[0], 'leading', firstNodesComments);
-    }
+    attachCommentsToOutputNodes(registry, finalNodesClone);
 
     return finalNodesClone;
 };

--- a/src/utils/adjust-comments-on-sorted-nodes.ts
+++ b/src/utils/adjust-comments-on-sorted-nodes.ts
@@ -29,8 +29,6 @@ export const adjustCommentsOnSortedNodes = (
     const registry = getCommentRegistryFromImportDeclarations({
         outputNodes,
         firstImport: originalDeclarationNodes[0],
-        lastImport:
-            originalDeclarationNodes[originalDeclarationNodes.length - 1],
     });
 
     // Make a copy of the nodes for easier debugging & remove the existing comments to reattach them

--- a/src/utils/adjust-comments-on-sorted-nodes.ts
+++ b/src/utils/adjust-comments-on-sorted-nodes.ts
@@ -22,7 +22,6 @@ export const adjustCommentsOnSortedNodes = (
     originalDeclarationNodes: ImportDeclaration[],
     finalNodes: ImportOrLine[],
 ) => {
-
     const outputDeclarationNodes: ImportDeclaration[] = finalNodes.filter(
         (n) => n.type === 'ImportDeclaration',
     ) as ImportDeclaration[];
@@ -43,7 +42,6 @@ export const adjustCommentsOnSortedNodes = (
             ).map((s) => removeComments(s));
         }
         return noDirectCommentsNode;
-
     });
 
     attachCommentsToOutputNodes(registry, finalNodesClone);

--- a/src/utils/adjust-comments-on-sorted-nodes.ts
+++ b/src/utils/adjust-comments-on-sorted-nodes.ts
@@ -1,8 +1,4 @@
-import {
-    addComments,
-    removeComments,
-    type ImportDeclaration,
-} from '@babel/types';
+import { removeComments, type ImportDeclaration } from '@babel/types';
 
 import { ImportOrLine } from '../types';
 import {
@@ -22,14 +18,20 @@ export const adjustCommentsOnSortedNodes = (
     originalDeclarationNodes: ImportDeclaration[],
     finalNodes: ImportOrLine[],
 ) => {
-    const outputDeclarationNodes: ImportDeclaration[] = finalNodes.filter(
+    const outputNodes: ImportDeclaration[] = finalNodes.filter(
         (n) => n.type === 'ImportDeclaration',
     ) as ImportDeclaration[];
+    if (originalDeclarationNodes.length === 0 || outputNodes.length === 0) {
+        // Nothing to do, because there are no ImportDeclarations!
+        return finalNodes;
+    }
 
-    const registry = getCommentRegistryFromImportDeclarations(
-        outputDeclarationNodes,
-        originalDeclarationNodes[0],
-    );
+    const registry = getCommentRegistryFromImportDeclarations({
+        outputNodes,
+        firstImport: originalDeclarationNodes[0],
+        lastImport:
+            originalDeclarationNodes[originalDeclarationNodes.length - 1],
+    });
 
     // Make a copy of the nodes for easier debugging & remove the existing comments to reattach them
     // (removeComments clones the nodes internally, so we don't need to do that ourselves)

--- a/src/utils/get-all-comments-from-nodes.ts
+++ b/src/utils/get-all-comments-from-nodes.ts
@@ -5,13 +5,32 @@ import type {
     Statement,
 } from '@babel/types';
 
-export const getAllCommentsFromNodes = (nodes: (Directive | Statement)[]) =>
+import { SomeSpecifier } from '../types';
+
+export const getAllCommentsFromNodes = (
+    nodes: (Directive | Statement | SomeSpecifier)[],
+) =>
     nodes.reduce((acc, node) => {
         if (
             Array.isArray(node.leadingComments) &&
             node.leadingComments.length > 0
         ) {
             acc = [...acc, ...node.leadingComments];
+        }
+        if (
+            Array.isArray(node.innerComments) &&
+            node.innerComments.length > 0
+        ) {
+            acc = [...acc, ...node.innerComments];
+        }
+        if (
+            Array.isArray(node.trailingComments) &&
+            node.trailingComments.length > 0
+        ) {
+            acc = [...acc, ...node.trailingComments];
+        }
+        if (node.type === 'ImportDeclaration') {
+            acc = [...acc, ...getAllCommentsFromNodes(node.specifiers)];
         }
         return acc;
     }, [] as (CommentBlock | CommentLine)[]);

--- a/src/utils/get-code-from-ast.ts
+++ b/src/utils/get-code-from-ast.ts
@@ -6,7 +6,12 @@ import {
     type Statement,
 } from '@babel/types';
 
-import { newLineCharacters } from '../constants';
+import {
+    newLineCharacters,
+    injectNewlinesRegex,
+    forceANewlineForImportsWithAttachedSingleLineCommentsRegex,
+    PATCH_BABEL_GENERATOR_DOUBLE_COMMENTS_ON_ONE_LINE_ISSUE,
+} from '../constants';
 import { getAllCommentsFromNodes } from './get-all-comments-from-nodes';
 import { removeNodesFromOriginalCode } from './remove-nodes-from-original-code';
 
@@ -70,10 +75,15 @@ export const getCodeFromAst = ({
 
     const { code } = generate(newAST);
 
-    return (
-        code.replace(
-            /"PRETTIER_PLUGIN_SORT_IMPORTS_NEW_LINE";/gi,
-            newLineCharacters,
-        ) + codeWithoutImportsAndInterpreter.trim()
-    );
+    let replacedCode = code.replace(injectNewlinesRegex, newLineCharacters);
+    if (PATCH_BABEL_GENERATOR_DOUBLE_COMMENTS_ON_ONE_LINE_ISSUE) {
+        replacedCode = replacedCode.replace(
+            forceANewlineForImportsWithAttachedSingleLineCommentsRegex,
+            '',
+        );
+    }
+
+    const trailingCode = codeWithoutImportsAndInterpreter.trim();
+
+    return replacedCode + trailingCode;
 };

--- a/src/utils/get-code-from-ast.ts
+++ b/src/utils/get-code-from-ast.ts
@@ -6,12 +6,7 @@ import {
     type Statement,
 } from '@babel/types';
 
-import {
-    forceANewlineForImportsWithAttachedSingleLineCommentsRegex,
-    injectNewlinesRegex,
-    newLineCharacters,
-    PATCH_BABEL_GENERATOR_DOUBLE_COMMENTS_ON_ONE_LINE_ISSUE,
-} from '../constants';
+import { injectNewlinesRegex, newLineCharacters } from '../constants';
 import { getAllCommentsFromNodes } from './get-all-comments-from-nodes';
 import { removeNodesFromOriginalCode } from './remove-nodes-from-original-code';
 
@@ -76,12 +71,6 @@ export const getCodeFromAst = ({
     const { code } = generate(newAST);
 
     let replacedCode = code.replace(injectNewlinesRegex, newLineCharacters);
-    if (PATCH_BABEL_GENERATOR_DOUBLE_COMMENTS_ON_ONE_LINE_ISSUE) {
-        replacedCode = replacedCode.replace(
-            forceANewlineForImportsWithAttachedSingleLineCommentsRegex,
-            '',
-        );
-    }
 
     const trailingCode = codeWithoutImportsAndInterpreter.trim();
 

--- a/src/utils/get-code-from-ast.ts
+++ b/src/utils/get-code-from-ast.ts
@@ -7,9 +7,9 @@ import {
 } from '@babel/types';
 
 import {
-    newLineCharacters,
-    injectNewlinesRegex,
     forceANewlineForImportsWithAttachedSingleLineCommentsRegex,
+    injectNewlinesRegex,
+    newLineCharacters,
     PATCH_BABEL_GENERATOR_DOUBLE_COMMENTS_ON_ONE_LINE_ISSUE,
 } from '../constants';
 import { getAllCommentsFromNodes } from './get-all-comments-from-nodes';

--- a/src/utils/get-code-from-ast.ts
+++ b/src/utils/get-code-from-ast.ts
@@ -70,7 +70,7 @@ export const getCodeFromAst = ({
 
     const { code } = generate(newAST);
 
-    let replacedCode = code.replace(injectNewlinesRegex, newLineCharacters);
+    const replacedCode = code.replace(injectNewlinesRegex, newLineCharacters);
 
     const trailingCode = codeWithoutImportsAndInterpreter.trim();
 

--- a/src/utils/get-comment-registry.ts
+++ b/src/utils/get-comment-registry.ts
@@ -315,14 +315,14 @@ export const getCommentRegistryFromImportDeclarations = ({
 
     // Merge in any comments that were orphaned, so they get reattached to their original owner
     for (const entry of deferredCommentClaims) {
-        const id = entry.commentId;
+        const { commentId } = entry;
         debugLog?.(
             'Processing deferred comment claim',
-            id,
+            commentId,
             entry.comment.value,
         );
 
-        if (!commentRegistry.has(id)) {
+        if (!commentRegistry.has(commentId)) {
             if (entry.ownerIsSpecifier) {
                 // Find the best specifier to attach to
                 const line = entry.comment.loc?.start.line || 0;
@@ -339,25 +339,25 @@ export const getCommentRegistryFromImportDeclarations = ({
 
                 debugLog?.(
                     'Reattaching',
-                    id,
+                    commentId,
                     entry.association,
                     targetAssociation,
                     entry.comment.value,
                     { hasNewOwner, owner, entry_owner: entry.owner },
                 );
 
-                commentRegistry.set(id, {
+                commentRegistry.set(commentId, {
                     ...entry,
                     owner,
                     association: targetAssociation,
                 });
             } else {
-                debugLog?.('Attaching orphan entry', id, entry);
-                commentRegistry.set(id, entry);
+                debugLog?.('Attaching orphan entry', commentId, entry);
+                commentRegistry.set(commentId, entry);
             }
         } else {
             debugLog?.(
-                `Skipping already-attached ${id} ${
+                `Skipping already-attached ${commentId} ${
                     entry.ownerIsSpecifier ? 'Specifier' : 'Declaration'
                 } ${entry.comment.value}`,
             );

--- a/src/utils/get-comment-registry.ts
+++ b/src/utils/get-comment-registry.ts
@@ -5,11 +5,11 @@ import {
 } from '@babel/types';
 
 import {
-    newLineNode,
     forceANewlineForImportsWithAttachedSingleLineComments,
+    newLineNode,
     PATCH_BABEL_GENERATOR_DOUBLE_COMMENTS_ON_ONE_LINE_ISSUE,
 } from '../constants';
-import { ImportOrLine, SomeSpecifier, ImportRelated } from '../types';
+import { ImportOrLine, ImportRelated, SomeSpecifier } from '../types';
 
 const SpecifierTypes = [
     'ImportSpecifier',

--- a/src/utils/get-comment-registry.ts
+++ b/src/utils/get-comment-registry.ts
@@ -1,0 +1,488 @@
+import {
+    emptyStatement,
+    type Comment,
+    type ImportDeclaration,
+} from '@babel/types';
+
+import {
+    newLineNode,
+    forceANewlineForImportsWithAttachedSingleLineComments,
+    PATCH_BABEL_GENERATOR_DOUBLE_COMMENTS_ON_ONE_LINE_ISSUE,
+} from '../constants';
+import { ImportOrLine, SomeSpecifier, ImportRelated } from '../types';
+
+const SpecifierTypes = [
+    'ImportSpecifier',
+    'ImportDefaultSpecifier',
+    'ImportNamespaceSpecifier',
+];
+
+function nodeId(node: Comment | ImportRelated): string {
+    if (node.type === 'ImportSpecifier') {
+        return `${node.type}::${node.start}::${
+            node.imported.type === 'StringLiteral'
+                ? node.imported.value
+                : node.imported.name
+        }`;
+    }
+    if (node.type === 'CommentLine') {
+        return `${node.type}::${node.start}::${node.loc.start.line}`;
+    }
+    return `${node.type}::${node.start}`;
+}
+
+export enum CommentAssociation {
+    leading = 'leading',
+    inner = 'inner',
+    trailing = 'trailing',
+}
+const CommentAssociationByKey = {
+    leadingComments: CommentAssociation.leading,
+    innerComments: CommentAssociation.inner,
+    trailingComments: CommentAssociation.trailing,
+} as const;
+const CommentAssociationByValue = {
+    [CommentAssociation.leading]: 'leadingComments' as const,
+    [CommentAssociation.inner]: 'innerComments' as const,
+    [CommentAssociation.trailing]: 'trailingComments' as const,
+} as const;
+const orderedCommentKeysToRegister = [
+    'innerComments', // Inner comments will be passed-through unchanged, so just collect them all first
+    'trailingComments', // Trailing comments might need to be paired with a node if they're on the same line, so collect them second
+    'leadingComments',
+] as const;
+
+export interface CommentEntry {
+    owner: ImportDeclaration | SomeSpecifier;
+    ownerIsSpecifier: boolean;
+    // Special case for leaving comments at top-of-file
+    needsTopOfFileOwner?: boolean;
+
+    commentId: string;
+    comment: Comment;
+    association: CommentAssociation;
+
+    /** We need to defer some claims and prioritize them after initial processing - higher is later processing */
+    processingPriority: number;
+}
+
+/** Magic number so that Specifier-linked comments are processed after other Comment-types  */
+const MAX_COUNT_OF_LIKELY_IMPORT_STATEMENTS = 10000;
+
+/** Lower number priority will be processed earlier! */
+enum DeferredCommentClaimPriorityAdjustment {
+    leadingSpecifier = MAX_COUNT_OF_LIKELY_IMPORT_STATEMENTS * 1,
+    trailingNonSameLine = MAX_COUNT_OF_LIKELY_IMPORT_STATEMENTS * 2,
+    leadingAboveAllImports = MAX_COUNT_OF_LIKELY_IMPORT_STATEMENTS * 3,
+}
+
+const debugLog: typeof console.debug | undefined = undefined as any; // undefined as any, because typescript is too smart
+// const debugLog: typeof console.debug = console.debug;
+
+/**
+ * Private helper for populating a comment-registry
+ *
+ * Walking the AST can find the same comment in multiple places,
+ *  so we need to collect them all, and attach them in our preferred order.
+ */
+const attachCommentsToRegistryMap = <
+    T extends ImportDeclaration | SomeSpecifier,
+>({
+    commentRegistry,
+    deferredCommentClaims,
+
+    attachmentKey,
+    comments,
+
+    owner,
+    firstImportDeclaration,
+}: {
+    commentRegistry: Map<string, CommentEntry>;
+    /**
+     * This parameter lets us defer some comment attachments and process them later.
+     */
+    deferredCommentClaims: CommentEntry[];
+
+    attachmentKey: (typeof orderedCommentKeysToRegister)[number];
+    comments: Comment[];
+
+    owner: T;
+
+    firstImportDeclaration: ImportDeclaration;
+}) => {
+    let commentCounter = 0;
+
+    for (const comment of comments) {
+        const commentId = nodeId(comment);
+        if (commentRegistry.has(commentId)) {
+            // This comment was already definitively registered to be paired with a different node, so we'll skip it
+            debugLog?.('Comment already registered', commentId);
+            continue;
+        }
+
+        // This node is needs to be attached somewhere.
+
+        const ownerIsSpecifier = SpecifierTypes.includes(owner.type);
+        const commentIsSingleLineType = comment.type === 'CommentLine';
+
+        const commentEntry: CommentEntry = {
+            owner,
+            ownerIsSpecifier,
+            commentId,
+            comment,
+            association: CommentAssociationByKey[attachmentKey],
+            processingPriority: commentCounter++,
+        };
+
+        if (attachmentKey === 'innerComments') {
+            // InnerComments are always attached to their original owner
+            commentRegistry.set(commentId, commentEntry);
+            continue;
+        }
+
+        const isSameLineAsCurrentOwner =
+            commentIsSingleLineType && // Prettier doesn't allow block comments to stay on same line as expressions
+            owner.loc?.start.line === comment.loc?.start.line;
+
+        // If there's a gap, but this is the first-import, don't treat this line as "attached to the next node"
+        const hasLeadingGap =
+            nodeId(owner) === nodeId(firstImportDeclaration) &&
+            comment.loc?.start.line < (owner.loc?.start.line || 0) - 1;
+
+        // If it's not on the same line, don't treat this line as "attached to the previous node"
+        const hasTrailingGap =
+            comment.loc?.start.line > (owner.loc?.start.line || 0) + 1;
+
+        if (attachmentKey === 'trailingComments') {
+            // Trailing comments might be on the same line "attached"
+            // Detect if this comment is on same line as the owner
+            // Or they might be double-counted (once in trailingComments and once in leadingComments of the next node)
+
+            debugLog?.({
+                isSameLineAsCurrentOwner,
+                hasLeadingGap,
+                hasTrailingGap,
+                owner,
+                comment,
+            });
+
+            if (isSameLineAsCurrentOwner) {
+                commentRegistry.set(commentId, commentEntry);
+            } else if (hasTrailingGap) {
+                // This comment is either a leading comment on the next node, or it's an unrelated comment following the imports
+                // Trailing comment, not on the same line, so either it will get attached correctly, or it will be dropped below imports
+                // [Intentional empty block]
+            } else {
+                // This comment should be kept close to the ImportDeclaration it follows
+                commentEntry.processingPriority +=
+                    DeferredCommentClaimPriorityAdjustment.trailingNonSameLine;
+                deferredCommentClaims.push(commentEntry);
+            }
+            continue; // Unnecessary, but explicit
+        } else if (attachmentKey === 'leadingComments') {
+            if (hasLeadingGap) {
+                debugLog?.('Found a disconnected leading comment', {
+                    comment,
+                    owner,
+                    owner_loc: owner.loc,
+                    comment_loc: comment.loc,
+                });
+
+                // This comment is probably a disconnected comment before all imports
+                deferredCommentClaims.push({
+                    ...commentEntry,
+                    needsTopOfFileOwner: true,
+                    processingPriority:
+                        commentEntry.processingPriority +
+                        DeferredCommentClaimPriorityAdjustment.leadingAboveAllImports,
+                });
+            } else {
+                if (ownerIsSpecifier) {
+                    debugLog?.(
+                        'Deferring leading specifier comment attachment',
+                        commentEntry.commentId,
+                        commentEntry.comment.value,
+                    );
+
+                    deferredCommentClaims.push({
+                        ...commentEntry,
+                        processingPriority:
+                            commentEntry.processingPriority +
+                            DeferredCommentClaimPriorityAdjustment.leadingSpecifier,
+                    });
+                } else {
+                    debugLog?.(
+                        'Attaching',
+                        attachmentKey,
+                        commentId,
+                        (owner as any)?.imported?.name,
+                        comment.value,
+                    );
+                    commentRegistry.set(commentId, commentEntry);
+                }
+            }
+            continue; // Unnecessary, but explicit
+        } else {
+            throw new Error(
+                `Unimplemented attachmentKey ${attachmentKey} for ${nodeId(
+                    owner,
+                )}`,
+            );
+        }
+    }
+};
+
+/**
+ * Utility that walks ImportDeclarations and the associated comment nodes
+ * It returns a list of CommentEntry objects that tell you which nodes comments should be associated with
+ */
+export const getCommentRegistryFromImportDeclarations = (
+    outputNodes: ImportDeclaration[],
+    /** Original first import declaration, not the output-node! */
+    firstImportDeclaration: ImportDeclaration,
+) => {
+    if (outputNodes.length === 0 || !firstImportDeclaration) {
+        return [];
+    }
+
+    const commentRegistry = new Map<string, CommentEntry>();
+    const deferredCommentClaims: CommentEntry[] = [];
+
+    /**
+     * Babel isn't as aggressive in pairing comments as both leading and trailing with Specifiers (as it does with ImportDeclarations)
+     * This table helps us re-parent to the best specifier.
+     * This registry is keyed by (original) line number, first witnessed specifier for a given line number wins.
+     */
+    const specifierRegistry = new Map<number, SomeSpecifier>();
+    outputNodes
+        .map((n) => n.specifiers)
+        .flat()
+        .forEach((specifier) => {
+            if (specifierRegistry.has(specifier.loc?.start.line || 0)) {
+                return;
+            }
+            specifierRegistry.set(specifier.loc?.start.line || 0, specifier);
+        });
+
+    // debugLog?.({
+    //     specifierRegistry: [...specifierRegistry.values()].map((s) => ({
+    //         line: s?.loc?.start.line,
+    //         name: (s as any).imported,
+    //     })),
+    // });
+
+    // Detach all comments, but keep their state.
+    // The babel renderer would otherwise move them around based on their original attachment.
+    // Register them in a specific order (inner, trailing, leading) so that they attach appropriately (ImportDeclarations)
+
+    for (const attachmentKey of orderedCommentKeysToRegister) {
+        debugLog?.(
+            '==============================================================',
+            attachmentKey,
+        );
+        for (const declarationNode of outputNodes) {
+            attachCommentsToRegistryMap({
+                commentRegistry,
+                deferredCommentClaims,
+                attachmentKey,
+                comments: Array.from(declarationNode[attachmentKey] || []),
+                owner: declarationNode,
+                firstImportDeclaration,
+            });
+
+            for (const specifierNode of declarationNode.specifiers) {
+                attachCommentsToRegistryMap({
+                    commentRegistry,
+                    deferredCommentClaims,
+                    attachmentKey,
+                    comments: Array.from(specifierNode[attachmentKey] || []),
+                    owner: specifierNode,
+                    firstImportDeclaration,
+                });
+            }
+        }
+    }
+
+    // Sort the deferred claims, so they get attached by increasing priority-number
+    deferredCommentClaims.sort(
+        (a, b) => a.processingPriority - b.processingPriority,
+    );
+
+    // Merge in any comments that were orphaned, so they get reattached to their original owner
+    for (const entry of deferredCommentClaims) {
+        const id = entry.commentId;
+        debugLog?.(
+            'Processing deferred comment claim',
+            id,
+            entry.comment.value,
+        );
+
+        if (!commentRegistry.has(id)) {
+            if (entry.ownerIsSpecifier) {
+                // Find the best specifier to attach to
+                const line = entry.comment.loc?.start.line || 0;
+                const owner = specifierRegistry.get(line) || entry.owner;
+                const hasNewOwner = nodeId(owner) !== nodeId(entry.owner);
+
+                const shouldPatchAssociation =
+                    entry.association === CommentAssociation.leading &&
+                    hasNewOwner;
+
+                const targetAssociation = shouldPatchAssociation
+                    ? CommentAssociation.trailing
+                    : entry.association;
+                if (shouldPatchAssociation) {
+                    debugLog?.(
+                        'Reattaching orphaned specifier comment to new owner',
+                        {
+                            old_line: line,
+                            old_association: entry.association,
+                            targetAssociation,
+                            old_owner: entry.owner,
+                            owner,
+                        },
+                    );
+                    debugLog?.({
+                        owner_loc: owner.loc?.start,
+                        comment_loc: entry.comment.loc.start,
+                    });
+                }
+
+                debugLog?.(
+                    'Reattaching2',
+                    id,
+                    entry.association,
+                    targetAssociation,
+                    entry.comment.value,
+                    { hasNewOwner, owner, entry_owner: entry.owner },
+                );
+                if (entry.comment.value === ' h3 leading single-line-comment') {
+                    debugLog?.(entry.comment);
+                }
+
+                commentRegistry.set(id, {
+                    ...entry,
+                    owner,
+                    association: targetAssociation,
+                });
+            } else {
+                debugLog?.('Attaching orphan entry', id, entry);
+                commentRegistry.set(id, entry);
+            }
+        } else {
+            debugLog?.(
+                `Skipping already-attached ${id} ${
+                    entry.ownerIsSpecifier ? 'Specifier' : 'Declaration'
+                } ${entry.comment.value}`,
+            );
+        }
+    }
+
+    const allCommentEntries = Array.from(commentRegistry.values());
+    allCommentEntries.sort(
+        (a, b) => a.processingPriority - b.processingPriority,
+    );
+    return allCommentEntries;
+};
+
+export function attachCommentsToOutputNodes(
+    commentEntriesFromRegistry: CommentEntry[],
+    outputNodes: ImportOrLine[],
+) {
+    if (outputNodes.length === 0) {
+        // attachCommentsToOutputNodes implies that there's at least one output node so this shouldn't happen
+        throw new Error(
+            "Fatal Internal Error: Can't attach comments to empty output",
+        );
+    }
+    if (outputNodes[0].type !== 'EmptyStatement') {
+        // Put in a dummy empty statement to attach top-of-file-comments to if one was not provided
+        outputNodes.unshift(emptyStatement());
+    }
+
+    const outputRegistry = new Map<string, ImportRelated>();
+    for (const outputNode of outputNodes) {
+        outputRegistry.set(nodeId(outputNode), outputNode);
+        if (outputNode.type === 'ImportDeclaration') {
+            for (const specifier of outputNode.specifiers) {
+                outputRegistry.set(nodeId(specifier), specifier);
+            }
+        }
+    }
+
+    for (const commentEntry of commentEntriesFromRegistry) {
+        const { owner, comment, association, needsTopOfFileOwner } =
+            commentEntry;
+
+        const ownerNode = needsTopOfFileOwner
+            ? outputNodes[0]
+            : outputRegistry.get(nodeId(owner));
+
+        if (!ownerNode) {
+            // Shouldn't be possible if you called this helper with the right inputs!
+            throw new Error("Fatal Internal Error: Couldn't find owner node");
+        }
+
+        // addComments(ownerNode, association, [comment]);
+        // using Babel's addComments will reverse the comments if you iteratively attach them, so push them directly
+        const commentCollection = (ownerNode[
+            CommentAssociationByValue[association]
+        ] = ownerNode[CommentAssociationByValue[association]] || []);
+        (commentCollection as Comment[]).push(comment);
+    }
+
+    // console.debug(
+    //     'outputNodes!',
+    //     outputNodes.map((n) =>
+    //         (n as any).specifiers?.map((s: SomeSpecifier) => ({
+    //             name: s.imported?.name,
+    //             leading: JSON.stringify(s.leadingComments),
+    //             trailing: JSON.stringify(s.trailingComments),
+    //         })),
+    //     ),
+    // );
+
+    if (PATCH_BABEL_GENERATOR_DOUBLE_COMMENTS_ON_ONE_LINE_ISSUE) {
+        outputNodes
+            .filter((n) => n.type === 'ImportDeclaration')
+            .map((n) => {
+                // Patching up another bug: babel will pull up a single-line trailing-comment
+                //  that follows an ImportDeclaration even if it wasn't supposed to be on the same line
+                const trailingComments = n.trailingComments;
+                if (
+                    Array.isArray(trailingComments) &&
+                    trailingComments.length >= 1
+                ) {
+                    if (
+                        trailingComments[0].type === 'CommentLine' &&
+                        trailingComments[0].loc?.start.line !== n.loc?.end.line
+                    ) {
+                        // This comment is on a different line, let's make sure there's a newline
+                        trailingComments.unshift(
+                            forceANewlineForImportsWithAttachedSingleLineComments(),
+                        );
+                    }
+                }
+                return n;
+            })
+            .map((n) => (n as ImportDeclaration).specifiers || [])
+            .flat()
+            .forEach((s) => {
+                (s.leadingComments as Comment[])?.unshift(
+                    forceANewlineForImportsWithAttachedSingleLineComments(),
+                );
+            });
+    }
+
+    if (Array.isArray(outputNodes[0].leadingComments)) {
+        if (outputNodes[0].leadingComments.length > 0) {
+            // Convert this to a newline node!
+            outputNodes[0] = {
+                ...newLineNode,
+                leadingComments: outputNodes[0].leadingComments,
+            };
+        } else {
+            outputNodes.shift(); // Remove the empty statement
+        }
+    }
+}

--- a/src/utils/get-comment-registry.ts
+++ b/src/utils/get-comment-registry.ts
@@ -144,7 +144,6 @@ const attachCommentsToRegistryMap = <
         const currentOwnerIsLastImport = nodeId(owner) === nodeId(lastImport);
 
         const isSameLineAsCurrentOwner =
-            commentIsSingleLineType && // Prettier doesn't allow block comments to stay on same line as expressions
             owner.loc?.start.line === comment.loc?.start.line;
 
         // endsMoreThanOneLineAboveOwner is used with firstImport to protect top-of-file comments, and pick the right ImportSpecifier when Specifiers are re-sorted

--- a/src/utils/get-comment-registry.ts
+++ b/src/utils/get-comment-registry.ts
@@ -149,11 +149,11 @@ const attachCommentsToRegistryMap = <
 
         // LeadingGap is used with firstImport to protect top-of-file comments, and pick the right ImportSpecifier when Specifiers are re-sorted
         const hasLeadingGap =
-            (comment.loc?.start.line || 0) < (owner.loc?.start.line || 0) - 1;
+            (comment.loc?.end.line || 0) < (owner.loc?.start.line || 0) - 1;
 
         // TrailingGap is used with lastImport to protect bottom-of-imports comments, and pick the right ImportSpecifier when Specifiers are re-sorted
         const hasTrailingGap =
-            (comment.loc?.start.line || 0) > (owner.loc?.start.line || 0) + 1;
+            (comment.loc?.start.line || 0) > (owner.loc?.end.line || 0) + 1;
 
         if (attachmentKey === 'trailingComments') {
             // Trailing comments might be on the same line "attached"

--- a/src/utils/get-sorted-import-specifiers.ts
+++ b/src/utils/get-sorted-import-specifiers.ts
@@ -8,6 +8,8 @@ import { naturalSort } from '../natural-sort';
  *
  * type imports are sorted separately, and placed after value imports.
  *
+ * Comments need to be fixed up so they attach to the right objects.
+ *
  * @param node Import declaration node
  */
 export const getSortedImportSpecifiers = (node: ImportDeclaration) => {

--- a/tests/Angular/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/Angular/__snapshots__/ppsi.spec.ts.snap
@@ -80,6 +80,7 @@ export class TemplateController {
 
 exports[`imports-with-side-effect-imports.js - typescript-verify > imports-with-side-effect-imports.js 1`] = `
 // I am top level comment in this file.
+
 import thirdParty0 from "third-party0";
 import something3 from "@core/something3";
 import thirdDisco0 from "third-disco0";
@@ -148,6 +149,7 @@ export class TemplateController {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // I am top level comment in this file.
+
 import thirdDisco0 from "third-disco0";
 import thirdParty0 from "third-party0";
 import otherthing3 from "@core/otherthing3";

--- a/tests/Angular/imports-with-side-effect-imports.js
+++ b/tests/Angular/imports-with-side-effect-imports.js
@@ -1,4 +1,5 @@
 // I am top level comment in this file.
+
 import thirdParty0 from "third-party0";
 import something3 from "@core/something3";
 import thirdDisco0 from "third-disco0";

--- a/tests/Babel/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/Babel/__snapshots__/ppsi.spec.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`imports-with-comments.js - babel-verify > imports-with-comments.js 1`] = `
 // I am top level comment in this file.
+
 import z from 'z';
 import threeLevelRelativePath from "../../../threeLevelRelativePath";
 import sameLevelRelativePath from "./sameLevelRelativePath";
@@ -20,6 +21,7 @@ function add(a,b) {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // I am top level comment in this file.
+
 import thirdParty from "third-party";
 import z from "z";
 import abc from "@core/abc";
@@ -41,6 +43,7 @@ function add(a, b) {
 
 exports[`imports-with-side-effect-imports.js - babel-verify > imports-with-side-effect-imports.js 1`] = `
 // I am top level comment in this file.
+
 import thirdParty0 from "third-party0";
 import something3 from "@core/something3";
 import thirdDisco0 from "third-disco0";
@@ -87,6 +90,7 @@ function add(a,b) {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // I am top level comment in this file.
+
 import thirdDisco0 from "third-disco0";
 import thirdParty0 from "third-party0";
 import otherthing3 from "@core/otherthing3";

--- a/tests/Babel/imports-with-comments.js
+++ b/tests/Babel/imports-with-comments.js
@@ -1,4 +1,5 @@
 // I am top level comment in this file.
+
 import z from 'z';
 import threeLevelRelativePath from "../../../threeLevelRelativePath";
 import sameLevelRelativePath from "./sameLevelRelativePath";

--- a/tests/Babel/imports-with-side-effect-imports.js
+++ b/tests/Babel/imports-with-side-effect-imports.js
@@ -1,4 +1,5 @@
 // I am top level comment in this file.
+
 import thirdParty0 from "third-party0";
 import something3 from "@core/something3";
 import thirdDisco0 from "third-disco0";

--- a/tests/Flow/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/Flow/__snapshots__/ppsi.spec.ts.snap
@@ -6,6 +6,7 @@ exports[`imports-with-comments.js - flow-verify > imports-with-comments.js 1`] =
  */
 
 // I am top level comment in this file.
+
 import { type Something } from './__generated__/';
 import threeLevelRelativePath from "../../../threeLevelRelativePath";
 import sameLevelRelativePath from "./sameLevelRelativePath";
@@ -34,6 +35,7 @@ export function givesAFoo3Obj(): AliasFoo3 {
  * @flow
  */
 // I am top level comment in this file.
+
 import thirdParty from "third-party";
 import abc from "@core/abc";
 import otherthing from "@core/otherthing";
@@ -68,6 +70,7 @@ exports[`imports-with-side-effect-imports.js - flow-verify > imports-with-side-e
  */
 
 // I am top level comment in this file.
+
 import thirdParty0 from "third-party0";
 import something3 from "@core/something3";
 import thirdDisco0 from "third-disco0";
@@ -128,6 +131,7 @@ export function givesAFoo3Obj(): AliasFoo3 {
  * @flow
  */
 // I am top level comment in this file.
+
 import thirdDisco0 from "third-disco0";
 import thirdParty0 from "third-party0";
 import otherthing3 from "@core/otherthing3";

--- a/tests/Flow/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/Flow/__snapshots__/ppsi.spec.ts.snap
@@ -34,7 +34,6 @@ export function givesAFoo3Obj(): AliasFoo3 {
 /**
  * @flow
  */
-
 // I am top level comment in this file.
 
 import thirdParty from "third-party";
@@ -131,7 +130,6 @@ export function givesAFoo3Obj(): AliasFoo3 {
 /**
  * @flow
  */
-
 // I am top level comment in this file.
 
 import thirdDisco0 from "third-disco0";
@@ -198,6 +196,8 @@ import {fooValue} from './foo';
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 /**
  * @flow
- */ import { fooValue, type Foo } from "./foo";
+ */
+
+import { fooValue, type Foo } from "./foo";
 
 `;

--- a/tests/Flow/imports-with-comments.js
+++ b/tests/Flow/imports-with-comments.js
@@ -3,6 +3,7 @@
  */
 
 // I am top level comment in this file.
+
 import { type Something } from './__generated__/';
 import threeLevelRelativePath from "../../../threeLevelRelativePath";
 import sameLevelRelativePath from "./sameLevelRelativePath";

--- a/tests/Flow/imports-with-side-effect-imports.js
+++ b/tests/Flow/imports-with-side-effect-imports.js
@@ -3,6 +3,7 @@
  */
 
 // I am top level comment in this file.
+
 import thirdParty0 from "third-party0";
 import something3 from "@core/something3";
 import thirdDisco0 from "third-disco0";

--- a/tests/ImportCommentsPreserved/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/ImportCommentsPreserved/__snapshots__/ppsi.spec.ts.snap
@@ -1,5 +1,19 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`import-comments-babel-pulling-single-line-bug.ts - typescript-verify > import-comments-babel-pulling-single-line-bug.ts 1`] = `
+
+import B from "b";
+// Trailing comment 1 (not supposed to be on same line)
+// Bottom of imports single-line comment
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import B from "b";
+// Trailing comment 1 (not supposed to be on same line)
+
+// Bottom of imports single-line comment
+
+`;
+
 exports[`import-comments-document-top-test1.ts - typescript-verify > import-comments-document-top-test1.ts 1`] = `
 // This is part of multiple-lines at document-top
 // Second line followed by a gap

--- a/tests/ImportCommentsPreserved/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/ImportCommentsPreserved/__snapshots__/ppsi.spec.ts.snap
@@ -84,15 +84,11 @@ import A from "a"; /* Trailing comment on same-line as A (babel doesn't like Com
 // Loose leading comment before imports (should not be dragged down with B)
 
 /* Trailing comment on same-line as B (babel doesn't like CommentBlocks on same-line as anything else, so it will be shifted to a clean line) */
-
 /* Trailing comment on first line after B (This is treated as a leading comment for next import A!) */
 
 /* Leading comment before A */
-import A from "a";
-/* Trailing comment on same-line as A (babel doesn't like CommentBlocks on same-line as anything else, so it will be shifted to a clean line) */
-
+import A from "a"; /* Trailing comment on same-line as A (babel doesn't like CommentBlocks on same-line as anything else, so it will be shifted to a clean line) */
 /* Trailing comment on first line after A (will initially, because this is "close" to last-import 'a' */
-
 /* Leading comment before B */
 import B from "b";
 
@@ -116,10 +112,10 @@ import A from "a"; // Trailing comment on same-line as A
 // Loose leading comment before imports (should not be dragged down with B)
 
 // Trailing comment on first line after B (This is treated as a leading comment for next import A!)
+
 // Leading comment before A
 import A from "a"; // Trailing comment on same-line as A
 // Trailing comment on first line after A (will follow A initially, because this is "close" to last-import 'a')
-
 // Leading comment before B
 import B from "b"; // Trailing comment on same-line as B
 
@@ -164,11 +160,8 @@ import {
     h4, // h4 same-line single-line-comment
 } from "h";
 import {
-    i1,
-    /* i1 same-line will be treated as trailing comment for i1 */
-    i2,
-    /* i2 same-line will be treated as leading comment for i1 */
-
+    i1 /* i1 same-line will be treated as trailing comment for i1 */,
+    i2 /* i2 same-line will be treated as leading comment for i1 */,
     /** i3 leading comment
      */
     i3,

--- a/tests/ImportCommentsPreserved/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/ImportCommentsPreserved/__snapshots__/ppsi.spec.ts.snap
@@ -3,12 +3,12 @@
 exports[`import-comments-babel-pulling-single-line-bug.ts - typescript-verify > import-comments-babel-pulling-single-line-bug.ts 1`] = `
 
 import B from "b";
-// Trailing comment 1 (not supposed to be on same line)
+// Trailing comment (not supposed to be on same line)
 // Bottom of imports single-line comment
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 import B from "b";
-// Trailing comment 1 (not supposed to be on same line)
+// Trailing comment (not supposed to be on same line)
 
 // Bottom of imports single-line comment
 

--- a/tests/ImportCommentsPreserved/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/ImportCommentsPreserved/__snapshots__/ppsi.spec.ts.snap
@@ -1,0 +1,171 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`import-comments-document-top-test1.ts - typescript-verify > import-comments-document-top-test1.ts 1`] = `
+// This is part of multiple-lines at document-top
+// Second line followed by a gap
+
+import b from "b";
+import a from "a";
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// This is part of multiple-lines at document-top
+// Second line followed by a gap
+
+import a from "a";
+import b from "b";
+
+`;
+
+exports[`import-comments-document-top-test2.ts - typescript-verify > import-comments-document-top-test2.ts 1`] = `
+/**
+ * This is part of multiple-lines at document-top
+ * Second line of text, comment is followed by a gap (gap gets eaten)
+ */
+
+import b from "b";
+import a from "a";
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/**
+ * This is part of multiple-lines at document-top
+ * Second line of text, comment is followed by a gap (gap gets eaten)
+ */
+
+import a from "a";
+import b from "b";
+
+`;
+
+exports[`import-comments-document-top-test3.ts - typescript-verify > import-comments-document-top-test3.ts 1`] = `
+/**
+ * This comment is before the whole block,
+ * it is not attached to the following import.
+ */
+
+import b from "b";
+import a from "a";
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/**
+ * This comment is before the whole block,
+ * it is not attached to the following import.
+ */
+
+import a from "a";
+import b from "b";
+
+`;
+
+exports[`import-comments-outer-comments-block-comments.ts - typescript-verify > import-comments-outer-comments-block-comments.ts 1`] = `
+// Loose leading comment before imports (should not be dragged down with B)
+
+/* Leading comment before B */
+import B from "b"; /* Trailing comment on same-line as B (babel doesn't like CommentBlocks on same-line as anything else, so it will be shifted to a clean line) */
+/* Trailing comment on first line after B (This is treated as a leading comment for next import A!) */
+
+
+/* Leading comment before A */
+import A from "a"; /* Trailing comment on same-line as A (babel doesn't like CommentBlocks on same-line as anything else, so it will be shifted to a clean line) */
+/* Trailing comment on first line after A (will initially, because this is "close" to last-import 'a' */
+
+// Loose trailing comment after imports (should not be dragged up with A)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Loose leading comment before imports (should not be dragged down with B)
+
+/* Trailing comment on same-line as B (babel doesn't like CommentBlocks on same-line as anything else, so it will be shifted to a clean line) */
+
+/* Trailing comment on first line after B (This is treated as a leading comment for next import A!) */
+
+/* Leading comment before A */
+import A from "a";
+/* Trailing comment on same-line as A (babel doesn't like CommentBlocks on same-line as anything else, so it will be shifted to a clean line) */
+
+/* Trailing comment on first line after A (will initially, because this is "close" to last-import 'a' */
+
+/* Leading comment before B */
+import B from "b";
+
+// Loose trailing comment after imports (should not be dragged up with A)
+
+`;
+
+exports[`import-comments-outer-comments-single-line.ts - typescript-verify > import-comments-outer-comments-single-line.ts 1`] = `
+// Loose leading comment before imports (should not be dragged down with B)
+
+// Leading comment before B
+import B from "b"; // Trailing comment on same-line as B
+// Trailing comment on first line after B (This is treated as a leading comment for next import A!)
+
+// Leading comment before A
+import A from "a"; // Trailing comment on same-line as A
+// Trailing comment on first line after A (will follow A initially, because this is "close" to last-import 'a')
+
+// Loose trailing comment after imports (should not be dragged up with A)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Loose leading comment before imports (should not be dragged down with B)
+
+// Trailing comment on first line after B (This is treated as a leading comment for next import A!)
+// Leading comment before A
+import A from "a"; // Trailing comment on same-line as A
+// Trailing comment on first line after A (will follow A initially, because this is "close" to last-import 'a')
+
+// Leading comment before B
+import B from "b"; // Trailing comment on same-line as B
+
+// Loose trailing comment after imports (should not be dragged up with A)
+
+`;
+
+exports[`import-comments-specifier-leading-and-trailing.ts - typescript-verify > import-comments-specifier-leading-and-trailing.ts 1`] = `
+// Top-of-file
+
+import {
+    // j3 leading single-line-comment 1
+    // j3 leading single-line-comment 2
+    j3, // j3 same-line single-line-comment
+    j2, // j2 same-line single-line-comment
+} from "j";
+
+import {
+    /** i3 leading comment
+      */ i3,
+    i2, /* i2 same-line will be treated as leading comment for i1 */
+    i1, /* i1 same-line will be treated as trailing comment for i1 */
+} from "i";
+
+import {
+    h4, // h4 same-line single-line-comment
+    // h3 leading single-line-comment
+    h3, // h3 same-line single-line-comment
+    h2, // h2 same-line single-line-comment
+    h1, // h1 same-line single-line-comment
+} from "h";
+
+// Rest of file below here
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Top-of-file
+
+import {
+    h1, // h1 same-line single-line-comment
+    h2, // h2 same-line single-line-comment
+    // h3 leading single-line-comment
+    h3, // h3 same-line single-line-comment
+    h4, // h4 same-line single-line-comment
+} from "h";
+import {
+    i1,
+    /* i1 same-line will be treated as trailing comment for i1 */
+    i2,
+    /* i2 same-line will be treated as leading comment for i1 */
+
+    /** i3 leading comment
+     */
+    i3,
+} from "i";
+import {
+    j2, // j2 same-line single-line-comment
+    // j3 leading single-line-comment 1
+    // j3 leading single-line-comment 2
+    j3, // j3 same-line single-line-comment
+} from "j";
+
+// Rest of file below here
+
+`;

--- a/tests/ImportCommentsPreserved/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/ImportCommentsPreserved/__snapshots__/ppsi.spec.ts.snap
@@ -8,8 +8,8 @@ import B from "b";
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 import B from "b";
-// Trailing comment (not supposed to be on same line)
 
+// Trailing comment (not supposed to be on same line)
 // Bottom of imports single-line comment
 
 `;
@@ -32,7 +32,7 @@ import b from "b";
 exports[`import-comments-document-top-test2.ts - typescript-verify > import-comments-document-top-test2.ts 1`] = `
 /**
  * This is part of multiple-lines at document-top
- * Second line of text, comment is followed by a gap (gap gets eaten)
+ * Second line of text, comment is followed by a gap
  */
 
 import b from "b";
@@ -40,26 +40,7 @@ import a from "a";
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 /**
  * This is part of multiple-lines at document-top
- * Second line of text, comment is followed by a gap (gap gets eaten)
- */
-
-import a from "a";
-import b from "b";
-
-`;
-
-exports[`import-comments-document-top-test3.ts - typescript-verify > import-comments-document-top-test3.ts 1`] = `
-/**
- * This comment is before the whole block,
- * it is not attached to the following import.
- */
-
-import b from "b";
-import a from "a";
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/**
- * This comment is before the whole block,
- * it is not attached to the following import.
+ * Second line of text, comment is followed by a gap
  */
 
 import a from "a";
@@ -71,26 +52,26 @@ exports[`import-comments-outer-comments-block-comments.ts - typescript-verify > 
 // Loose leading comment before imports (should not be dragged down with B)
 
 /* Leading comment before B */
-import B from "b"; /* Trailing comment on same-line as B (babel doesn't like CommentBlocks on same-line as anything else, so it will be shifted to a clean line) */
-/* Trailing comment on first line after B (This is treated as a leading comment for next import A!) */
+import B from "b"; /* Trailing comment on same-line as B */
+/* Trailing comment on first line after B (this is treated as a leading comment for next import A!) */
 
 
 /* Leading comment before A */
-import A from "a"; /* Trailing comment on same-line as A (babel doesn't like CommentBlocks on same-line as anything else, so it will be shifted to a clean line) */
-/* Trailing comment on first line after A (will initially, because this is "close" to last-import 'a' */
+import A from "a"; /* Trailing comment on same-line as A */
+/* Trailing comment on first line after A (this is treated as a "bottom-of-imports comment) */
 
 // Loose trailing comment after imports (should not be dragged up with A)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Loose leading comment before imports (should not be dragged down with B)
 
-/* Trailing comment on same-line as B (babel doesn't like CommentBlocks on same-line as anything else, so it will be shifted to a clean line) */
-/* Trailing comment on first line after B (This is treated as a leading comment for next import A!) */
+/* Trailing comment on first line after B (this is treated as a leading comment for next import A!) */
 
 /* Leading comment before A */
-import A from "a"; /* Trailing comment on same-line as A (babel doesn't like CommentBlocks on same-line as anything else, so it will be shifted to a clean line) */
-/* Trailing comment on first line after A (will initially, because this is "close" to last-import 'a' */
+import A from "a"; /* Trailing comment on same-line as A */
 /* Leading comment before B */
-import B from "b";
+import B from "b"; /* Trailing comment on same-line as B */
+
+/* Trailing comment on first line after A (this is treated as a "bottom-of-imports comment) */
 
 // Loose trailing comment after imports (should not be dragged up with A)
 
@@ -101,23 +82,24 @@ exports[`import-comments-outer-comments-single-line.ts - typescript-verify > imp
 
 // Leading comment before B
 import B from "b"; // Trailing comment on same-line as B
-// Trailing comment on first line after B (This is treated as a leading comment for next import A!)
+// Trailing comment on first line after B (this is treated as a leading comment for next import A!)
 
 // Leading comment before A
 import A from "a"; // Trailing comment on same-line as A
-// Trailing comment on first line after A (will follow A initially, because this is "close" to last-import 'a')
+// Trailing comment on first line after A (this is treated as a "bottom-of-imports comment)
 
 // Loose trailing comment after imports (should not be dragged up with A)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Loose leading comment before imports (should not be dragged down with B)
 
-// Trailing comment on first line after B (This is treated as a leading comment for next import A!)
+// Trailing comment on first line after B (this is treated as a leading comment for next import A!)
 
 // Leading comment before A
 import A from "a"; // Trailing comment on same-line as A
-// Trailing comment on first line after A (will follow A initially, because this is "close" to last-import 'a')
 // Leading comment before B
 import B from "b"; // Trailing comment on same-line as B
+
+// Trailing comment on first line after A (this is treated as a "bottom-of-imports comment)
 
 // Loose trailing comment after imports (should not be dragged up with A)
 

--- a/tests/ImportCommentsPreserved/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/ImportCommentsPreserved/__snapshots__/ppsi.spec.ts.snap
@@ -51,6 +51,9 @@ import b from "b";
 exports[`import-comments-outer-comments-block-comments.ts - typescript-verify > import-comments-outer-comments-block-comments.ts 1`] = `
 // Loose leading comment before imports (should not be dragged down with B)
 
+import C from "c" /* trailing comment that spans
+                     onto the following line */
+
 /* Leading comment before B */
 import B from "b"; /* Trailing comment on same-line as B */
 /* Trailing comment on first line after B (this is treated as a leading comment for next import A!) */
@@ -70,6 +73,8 @@ import A from "a"; /* Trailing comment on same-line as A */
 import A from "a"; /* Trailing comment on same-line as A */
 /* Leading comment before B */
 import B from "b"; /* Trailing comment on same-line as B */
+import C from "c"; /* trailing comment that spans
+                      onto the following line */
 
 /* Trailing comment on first line after A (this is treated as a "bottom-of-imports comment) */
 

--- a/tests/ImportCommentsPreserved/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/ImportCommentsPreserved/__snapshots__/ppsi.spec.ts.snap
@@ -118,8 +118,10 @@ import {
 import {
     /** i3 leading comment
       */ i3,
-    i2, /* i2 same-line will be treated as leading comment for i1 */
-    i1, /* i1 same-line will be treated as trailing comment for i1 */
+    i2, /* i2 same-line block */
+    i4, /* i4 multi-line
+        block */
+    i1, /* i1 same-line block */
 } from "i";
 
 import {
@@ -142,11 +144,13 @@ import {
     h4, // h4 same-line single-line-comment
 } from "h";
 import {
-    i1 /* i1 same-line will be treated as trailing comment for i1 */,
-    i2 /* i2 same-line will be treated as leading comment for i1 */,
+    i1 /* i1 same-line block */,
+    i2 /* i2 same-line block */,
     /** i3 leading comment
      */
     i3,
+    i4 /* i4 multi-line
+       block */,
 } from "i";
 import {
     j2, // j2 same-line single-line-comment

--- a/tests/ImportCommentsPreserved/import-comments-babel-pulling-single-line-bug.ts
+++ b/tests/ImportCommentsPreserved/import-comments-babel-pulling-single-line-bug.ts
@@ -1,0 +1,5 @@
+
+import B from "b";
+// Trailing comment (not supposed to be on same line)
+// Bottom of imports single-line comment
+

--- a/tests/ImportCommentsPreserved/import-comments-document-top-test1.ts
+++ b/tests/ImportCommentsPreserved/import-comments-document-top-test1.ts
@@ -1,0 +1,5 @@
+// This is part of multiple-lines at document-top
+// Second line followed by a gap
+
+import b from "b";
+import a from "a";

--- a/tests/ImportCommentsPreserved/import-comments-document-top-test2.ts
+++ b/tests/ImportCommentsPreserved/import-comments-document-top-test2.ts
@@ -1,0 +1,7 @@
+/**
+ * This is part of multiple-lines at document-top
+ * Second line of text, comment is followed by a gap (gap gets eaten)
+ */
+
+import b from "b";
+import a from "a";

--- a/tests/ImportCommentsPreserved/import-comments-document-top-test2.ts
+++ b/tests/ImportCommentsPreserved/import-comments-document-top-test2.ts
@@ -1,6 +1,6 @@
 /**
  * This is part of multiple-lines at document-top
- * Second line of text, comment is followed by a gap (gap gets eaten)
+ * Second line of text, comment is followed by a gap
  */
 
 import b from "b";

--- a/tests/ImportCommentsPreserved/import-comments-document-top-test3.ts
+++ b/tests/ImportCommentsPreserved/import-comments-document-top-test3.ts
@@ -1,7 +1,0 @@
-/**
- * This comment is before the whole block,
- * it is not attached to the following import.
- */
-
-import b from "b";
-import a from "a";

--- a/tests/ImportCommentsPreserved/import-comments-document-top-test3.ts
+++ b/tests/ImportCommentsPreserved/import-comments-document-top-test3.ts
@@ -1,0 +1,7 @@
+/**
+ * This comment is before the whole block,
+ * it is not attached to the following import.
+ */
+
+import b from "b";
+import a from "a";

--- a/tests/ImportCommentsPreserved/import-comments-outer-comments-block-comments.ts
+++ b/tests/ImportCommentsPreserved/import-comments-outer-comments-block-comments.ts
@@ -1,0 +1,12 @@
+// Loose leading comment before imports (should not be dragged down with B)
+
+/* Leading comment before B */
+import B from "b"; /* Trailing comment on same-line as B (babel doesn't like CommentBlocks on same-line as anything else, so it will be shifted to a clean line) */
+/* Trailing comment on first line after B (This is treated as a leading comment for next import A!) */
+
+
+/* Leading comment before A */
+import A from "a"; /* Trailing comment on same-line as A (babel doesn't like CommentBlocks on same-line as anything else, so it will be shifted to a clean line) */
+/* Trailing comment on first line after A (will initially, because this is "close" to last-import 'a' */
+
+// Loose trailing comment after imports (should not be dragged up with A)

--- a/tests/ImportCommentsPreserved/import-comments-outer-comments-block-comments.ts
+++ b/tests/ImportCommentsPreserved/import-comments-outer-comments-block-comments.ts
@@ -1,12 +1,12 @@
 // Loose leading comment before imports (should not be dragged down with B)
 
 /* Leading comment before B */
-import B from "b"; /* Trailing comment on same-line as B (babel doesn't like CommentBlocks on same-line as anything else, so it will be shifted to a clean line) */
-/* Trailing comment on first line after B (This is treated as a leading comment for next import A!) */
+import B from "b"; /* Trailing comment on same-line as B */
+/* Trailing comment on first line after B (this is treated as a leading comment for next import A!) */
 
 
 /* Leading comment before A */
-import A from "a"; /* Trailing comment on same-line as A (babel doesn't like CommentBlocks on same-line as anything else, so it will be shifted to a clean line) */
-/* Trailing comment on first line after A (will initially, because this is "close" to last-import 'a' */
+import A from "a"; /* Trailing comment on same-line as A */
+/* Trailing comment on first line after A (this is treated as a "bottom-of-imports comment) */
 
 // Loose trailing comment after imports (should not be dragged up with A)

--- a/tests/ImportCommentsPreserved/import-comments-outer-comments-block-comments.ts
+++ b/tests/ImportCommentsPreserved/import-comments-outer-comments-block-comments.ts
@@ -1,5 +1,8 @@
 // Loose leading comment before imports (should not be dragged down with B)
 
+import C from "c" /* trailing comment that spans
+                     onto the following line */
+
 /* Leading comment before B */
 import B from "b"; /* Trailing comment on same-line as B */
 /* Trailing comment on first line after B (this is treated as a leading comment for next import A!) */

--- a/tests/ImportCommentsPreserved/import-comments-outer-comments-single-line.ts
+++ b/tests/ImportCommentsPreserved/import-comments-outer-comments-single-line.ts
@@ -2,10 +2,10 @@
 
 // Leading comment before B
 import B from "b"; // Trailing comment on same-line as B
-// Trailing comment on first line after B (This is treated as a leading comment for next import A!)
+// Trailing comment on first line after B (this is treated as a leading comment for next import A!)
 
 // Leading comment before A
 import A from "a"; // Trailing comment on same-line as A
-// Trailing comment on first line after A (will follow A initially, because this is "close" to last-import 'a')
+// Trailing comment on first line after A (this is treated as a "bottom-of-imports comment)
 
 // Loose trailing comment after imports (should not be dragged up with A)

--- a/tests/ImportCommentsPreserved/import-comments-outer-comments-single-line.ts
+++ b/tests/ImportCommentsPreserved/import-comments-outer-comments-single-line.ts
@@ -1,0 +1,11 @@
+// Loose leading comment before imports (should not be dragged down with B)
+
+// Leading comment before B
+import B from "b"; // Trailing comment on same-line as B
+// Trailing comment on first line after B (This is treated as a leading comment for next import A!)
+
+// Leading comment before A
+import A from "a"; // Trailing comment on same-line as A
+// Trailing comment on first line after A (will follow A initially, because this is "close" to last-import 'a')
+
+// Loose trailing comment after imports (should not be dragged up with A)

--- a/tests/ImportCommentsPreserved/import-comments-specifier-leading-and-trailing.ts
+++ b/tests/ImportCommentsPreserved/import-comments-specifier-leading-and-trailing.ts
@@ -10,8 +10,10 @@ import {
 import {
     /** i3 leading comment
       */ i3,
-    i2, /* i2 same-line will be treated as leading comment for i1 */
-    i1, /* i1 same-line will be treated as trailing comment for i1 */
+    i2, /* i2 same-line block */
+    i4, /* i4 multi-line
+        block */
+    i1, /* i1 same-line block */
 } from "i";
 
 import {

--- a/tests/ImportCommentsPreserved/import-comments-specifier-leading-and-trailing.ts
+++ b/tests/ImportCommentsPreserved/import-comments-specifier-leading-and-trailing.ts
@@ -1,0 +1,25 @@
+// Top-of-file
+
+import {
+    // j3 leading single-line-comment 1
+    // j3 leading single-line-comment 2
+    j3, // j3 same-line single-line-comment
+    j2, // j2 same-line single-line-comment
+} from "j";
+
+import {
+    /** i3 leading comment
+      */ i3,
+    i2, /* i2 same-line will be treated as leading comment for i1 */
+    i1, /* i1 same-line will be treated as trailing comment for i1 */
+} from "i";
+
+import {
+    h4, // h4 same-line single-line-comment
+    // h3 leading single-line-comment
+    h3, // h3 same-line single-line-comment
+    h2, // h2 same-line single-line-comment
+    h1, // h1 same-line single-line-comment
+} from "h";
+
+// Rest of file below here

--- a/tests/ImportCommentsPreserved/ppsi.spec.ts
+++ b/tests/ImportCommentsPreserved/ppsi.spec.ts
@@ -1,0 +1,6 @@
+import {run_spec} from '../../test-setup/run_spec';
+
+run_spec(__dirname, ["typescript"], {
+    importOrder: ['^@core/(.*)$', '^@server/(.*)', '^@ui/(.*)$', '^[./]'],
+    importOrderParserPlugins : ['typescript', 'decorators-legacy', 'classProperties']
+});

--- a/tests/ImportsNotSeparated/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/ImportsNotSeparated/__snapshots__/ppsi.spec.ts.snap
@@ -102,8 +102,8 @@ function add(a:number,b:number) {
 
 import "./commands";
 import React from "react";
-
 // Comment
+
 // Comment
 
 function add(a: number, b: number) {

--- a/tests/ImportsNotSeparated/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/ImportsNotSeparated/__snapshots__/ppsi.spec.ts.snap
@@ -170,7 +170,7 @@ import thirdParty from "third-party";
 import {
     random // inner comment
 } from './random';
-// leading comment
+// trailing comment for import-random (export statement is code that will be sorted to below imports, and so doesn't have precedence over the import-comment-attachment rules!)
 export {
     random // inner comment
 } from './random';
@@ -212,10 +212,10 @@ import oneLevelRelativePath from "../oneLevelRelativePath";
 import {
     random, // inner comment
 } from "./random";
+// trailing comment for import-random (export statement is code that will be sorted to below imports, and so doesn't have precedence over the import-comment-attachment rules!)
 // I am stick to sameLevelRelativePath
 import sameLevelRelativePath from "./sameLevelRelativePath";
 
-// leading comment
 export {
     random, // inner comment
 } from "./random";

--- a/tests/ImportsNotSeparated/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/ImportsNotSeparated/__snapshots__/ppsi.spec.ts.snap
@@ -60,6 +60,7 @@ export const a = 1;
 exports[`imports-with-comments.ts - typescript-verify > imports-with-comments.ts 1`] = `
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
+
 import './commands';
 
 // Comment
@@ -71,6 +72,7 @@ function add(a:number,b:number) {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
+
 import "./commands";
 
 // Comment
@@ -85,6 +87,7 @@ function add(a: number, b: number) {
 exports[`imports-with-comments-and-third-party.ts - typescript-verify > imports-with-comments-and-third-party.ts 1`] = `
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
+
 import './commands';
 import React from 'react';
 // Comment
@@ -96,6 +99,7 @@ function add(a:number,b:number) {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
+
 import "./commands";
 import React from "react";
 
@@ -111,6 +115,7 @@ function add(a: number, b: number) {
 exports[`imports-with-comments-on-top.ts - typescript-verify > imports-with-comments-on-top.ts 1`] = `
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
+
 import z from 'z';
 import threeLevelRelativePath from "../../../threeLevelRelativePath";
 import sameLevelRelativePath from "./sameLevelRelativePath";
@@ -131,6 +136,7 @@ function add(a:number,b:number) {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
+
 import thirdParty from "third-party";
 import z from "z";
 import abc from "@core/abc";
@@ -154,6 +160,7 @@ function add(a: number, b: number) {
 exports[`imports-with-file-level-comments.ts - typescript-verify > imports-with-file-level-comments.ts 1`] = `
 //@ts-ignore
 // I am file top level comments
+
 import threeLevelRelativePath from "../../../threeLevelRelativePath";
 // I am stick to sameLevelRelativePath
 import sameLevelRelativePath from "./sameLevelRelativePath";
@@ -188,6 +195,7 @@ function add(a:number,b:number) {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 //@ts-ignore
 // I am file top level comments
+
 import a from "a";
 import c from "c";
 // I am stick to third party comment
@@ -257,6 +265,7 @@ function add(a: number, b: number) {
 
 exports[`imports-without-third-party.ts - typescript-verify > imports-without-third-party.ts 1`] = `
 // I am top level comment
+
 import otherthing from "@core/otherthing";
 import abc from "@core/abc";
 // I am comment
@@ -266,6 +275,7 @@ import fourLevelRelativePath from "../../../../fourLevelRelativePath";
 import something from "@server/something";
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // I am top level comment
+
 import abc from "@core/abc";
 import otherthing from "@core/otherthing";
 import something from "@server/something";
@@ -321,6 +331,7 @@ import './commands';
 // You can read more here:
 // https://on.cypress.io/configuration
 // ***********************************************************
+
 // Import commands.js using ES2015 syntax:
 import "./commands";
 

--- a/tests/ImportsNotSeparated/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/ImportsNotSeparated/__snapshots__/ppsi.spec.ts.snap
@@ -102,8 +102,8 @@ function add(a:number,b:number) {
 
 import "./commands";
 import React from "react";
-// Comment
 
+// Comment
 // Comment
 
 function add(a: number, b: number) {
@@ -170,7 +170,7 @@ import thirdParty from "third-party";
 import {
     random // inner comment
 } from './random';
-// trailing comment for import-random (export statement is code that will be sorted to below imports, and so doesn't have precedence over the import-comment-attachment rules!)
+// leading comment for export from random
 export {
     random // inner comment
 } from './random';
@@ -212,10 +212,10 @@ import oneLevelRelativePath from "../oneLevelRelativePath";
 import {
     random, // inner comment
 } from "./random";
-// trailing comment for import-random (export statement is code that will be sorted to below imports, and so doesn't have precedence over the import-comment-attachment rules!)
 // I am stick to sameLevelRelativePath
 import sameLevelRelativePath from "./sameLevelRelativePath";
 
+// leading comment for export from random
 export {
     random, // inner comment
 } from "./random";

--- a/tests/ImportsNotSeparated/imports-with-comments-and-third-party.ts
+++ b/tests/ImportsNotSeparated/imports-with-comments-and-third-party.ts
@@ -1,5 +1,6 @@
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
+
 import './commands';
 import React from 'react';
 // Comment

--- a/tests/ImportsNotSeparated/imports-with-comments-on-top.ts
+++ b/tests/ImportsNotSeparated/imports-with-comments-on-top.ts
@@ -1,5 +1,6 @@
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
+
 import z from 'z';
 import threeLevelRelativePath from "../../../threeLevelRelativePath";
 import sameLevelRelativePath from "./sameLevelRelativePath";

--- a/tests/ImportsNotSeparated/imports-with-comments.ts
+++ b/tests/ImportsNotSeparated/imports-with-comments.ts
@@ -1,5 +1,6 @@
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
+
 import './commands';
 
 // Comment

--- a/tests/ImportsNotSeparated/imports-with-file-level-comments.ts
+++ b/tests/ImportsNotSeparated/imports-with-file-level-comments.ts
@@ -10,7 +10,7 @@ import thirdParty from "third-party";
 import {
     random // inner comment
 } from './random';
-// leading comment
+// trailing comment for import-random (export statement is code that will be sorted to below imports, and so doesn't have precedence over the import-comment-attachment rules!)
 export {
     random // inner comment
 } from './random';

--- a/tests/ImportsNotSeparated/imports-with-file-level-comments.ts
+++ b/tests/ImportsNotSeparated/imports-with-file-level-comments.ts
@@ -1,5 +1,6 @@
 //@ts-ignore
 // I am file top level comments
+
 import threeLevelRelativePath from "../../../threeLevelRelativePath";
 // I am stick to sameLevelRelativePath
 import sameLevelRelativePath from "./sameLevelRelativePath";

--- a/tests/ImportsNotSeparated/imports-with-file-level-comments.ts
+++ b/tests/ImportsNotSeparated/imports-with-file-level-comments.ts
@@ -10,7 +10,7 @@ import thirdParty from "third-party";
 import {
     random // inner comment
 } from './random';
-// trailing comment for import-random (export statement is code that will be sorted to below imports, and so doesn't have precedence over the import-comment-attachment rules!)
+// leading comment for export from random
 export {
     random // inner comment
 } from './random';

--- a/tests/ImportsNotSeparated/imports-without-third-party.ts
+++ b/tests/ImportsNotSeparated/imports-without-third-party.ts
@@ -1,4 +1,5 @@
 // I am top level comment
+
 import otherthing from "@core/otherthing";
 import abc from "@core/abc";
 // I am comment

--- a/tests/ImportsSeparatedByEmptyRegex/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/ImportsSeparatedByEmptyRegex/__snapshots__/ppsi.spec.ts.snap
@@ -227,7 +227,7 @@ import thirdParty from "third-party";
 import {
     random // inner comment
 } from './random';
-// leading comment
+// trailing comment for import-random (export statement is code that will be sorted to below imports, and so doesn't have precedence over the import-comment-attachment rules!)
 export {
     random // inner comment
 } from './random';
@@ -271,10 +271,10 @@ import oneLevelRelativePath from "../oneLevelRelativePath";
 import {
     random, // inner comment
 } from "./random";
+// trailing comment for import-random (export statement is code that will be sorted to below imports, and so doesn't have precedence over the import-comment-attachment rules!)
 // I am stick to sameLevelRelativePath
 import sameLevelRelativePath from "./sameLevelRelativePath";
 
-// leading comment
 export {
     random, // inner comment
 } from "./random";

--- a/tests/ImportsSeparatedByEmptyRegex/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/ImportsSeparatedByEmptyRegex/__snapshots__/ppsi.spec.ts.snap
@@ -157,8 +157,8 @@ function add(a:number,b:number) {
 import "./commands";
 
 import React from "react";
-
 // Comment
+
 // Comment
 
 function add(a: number, b: number) {

--- a/tests/ImportsSeparatedByEmptyRegex/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/ImportsSeparatedByEmptyRegex/__snapshots__/ppsi.spec.ts.snap
@@ -114,6 +114,7 @@ export const a = 1;
 exports[`imports-with-comments.ts - typescript-verify > imports-with-comments.ts 1`] = `
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
+
 import './commands';
 
 // Comment
@@ -125,6 +126,7 @@ function add(a:number,b:number) {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
+
 import "./commands";
 
 // Comment
@@ -139,6 +141,7 @@ function add(a: number, b: number) {
 exports[`imports-with-comments-and-third-party.ts - typescript-verify > imports-with-comments-and-third-party.ts 1`] = `
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
+
 import './commands';
 import React from 'react';
 // Comment
@@ -150,6 +153,7 @@ function add(a:number,b:number) {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
+
 import "./commands";
 
 import React from "react";
@@ -166,6 +170,7 @@ function add(a: number, b: number) {
 exports[`imports-with-comments-on-top.ts - typescript-verify > imports-with-comments-on-top.ts 1`] = `
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
+
 import z from 'z';
 import threeLevelRelativePath from "../../../threeLevelRelativePath";
 import sameLevelRelativePath from "./sameLevelRelativePath";
@@ -186,6 +191,7 @@ function add(a:number,b:number) {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
+
 import thirdParty from "third-party";
 import z from "z";
 
@@ -211,6 +217,7 @@ function add(a: number, b: number) {
 exports[`imports-with-file-level-comments.ts - typescript-verify > imports-with-file-level-comments.ts 1`] = `
 //@ts-ignore
 // I am file top level comments
+
 import threeLevelRelativePath from "../../../threeLevelRelativePath";
 // I am stick to sameLevelRelativePath
 import sameLevelRelativePath from "./sameLevelRelativePath";
@@ -245,6 +252,7 @@ function add(a:number,b:number) {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 //@ts-ignore
 // I am file top level comments
+
 import a from "a";
 import c from "c";
 // I am stick to third party comment
@@ -317,6 +325,7 @@ function add(a: number, b: number) {
 
 exports[`imports-with-side-effect-imports.ts - typescript-verify > imports-with-side-effect-imports.ts 1`] = `
 // I am top level comment in this file.
+
 import thirdParty0 from "third-party0";
 import something3 from "@core/something3";
 import thirdDisco0 from "third-disco0";
@@ -372,6 +381,7 @@ export function givesAFoo3Obj(): AliasFoo3 {
 };
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // I am top level comment in this file.
+
 import thirdDisco0 from "third-disco0";
 import thirdParty0 from "third-party0";
 
@@ -440,6 +450,7 @@ export function givesAFoo3Obj(): AliasFoo3 {
 
 exports[`imports-without-third-party.ts - typescript-verify > imports-without-third-party.ts 1`] = `
 // I am top level comment
+
 import otherthing from "@core/otherthing";
 import abc from "@core/abc";
 // I am comment
@@ -449,6 +460,7 @@ import fourLevelRelativePath from "../../../../fourLevelRelativePath";
 import something from "@server/something";
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // I am top level comment
+
 import abc from "@core/abc";
 import otherthing from "@core/otherthing";
 import something from "@server/something";
@@ -505,6 +517,7 @@ import './commands';
 // You can read more here:
 // https://on.cypress.io/configuration
 // ***********************************************************
+
 // Import commands.js using ES2015 syntax:
 import "./commands";
 

--- a/tests/ImportsSeparatedByEmptyRegex/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/ImportsSeparatedByEmptyRegex/__snapshots__/ppsi.spec.ts.snap
@@ -157,8 +157,8 @@ function add(a:number,b:number) {
 import "./commands";
 
 import React from "react";
-// Comment
 
+// Comment
 // Comment
 
 function add(a: number, b: number) {
@@ -227,7 +227,7 @@ import thirdParty from "third-party";
 import {
     random // inner comment
 } from './random';
-// trailing comment for import-random (export statement is code that will be sorted to below imports, and so doesn't have precedence over the import-comment-attachment rules!)
+// leading comment for export from random
 export {
     random // inner comment
 } from './random';
@@ -271,10 +271,10 @@ import oneLevelRelativePath from "../oneLevelRelativePath";
 import {
     random, // inner comment
 } from "./random";
-// trailing comment for import-random (export statement is code that will be sorted to below imports, and so doesn't have precedence over the import-comment-attachment rules!)
 // I am stick to sameLevelRelativePath
 import sameLevelRelativePath from "./sameLevelRelativePath";
 
+// leading comment for export from random
 export {
     random, // inner comment
 } from "./random";

--- a/tests/ImportsSeparatedByEmptyRegex/imports-with-comments-and-third-party.ts
+++ b/tests/ImportsSeparatedByEmptyRegex/imports-with-comments-and-third-party.ts
@@ -1,5 +1,6 @@
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
+
 import './commands';
 import React from 'react';
 // Comment

--- a/tests/ImportsSeparatedByEmptyRegex/imports-with-comments-on-top.ts
+++ b/tests/ImportsSeparatedByEmptyRegex/imports-with-comments-on-top.ts
@@ -1,5 +1,6 @@
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
+
 import z from 'z';
 import threeLevelRelativePath from "../../../threeLevelRelativePath";
 import sameLevelRelativePath from "./sameLevelRelativePath";

--- a/tests/ImportsSeparatedByEmptyRegex/imports-with-comments.ts
+++ b/tests/ImportsSeparatedByEmptyRegex/imports-with-comments.ts
@@ -1,5 +1,6 @@
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
+
 import './commands';
 
 // Comment

--- a/tests/ImportsSeparatedByEmptyRegex/imports-with-file-level-comments.ts
+++ b/tests/ImportsSeparatedByEmptyRegex/imports-with-file-level-comments.ts
@@ -10,7 +10,7 @@ import thirdParty from "third-party";
 import {
     random // inner comment
 } from './random';
-// leading comment
+// trailing comment for import-random (export statement is code that will be sorted to below imports, and so doesn't have precedence over the import-comment-attachment rules!)
 export {
     random // inner comment
 } from './random';

--- a/tests/ImportsSeparatedByEmptyRegex/imports-with-file-level-comments.ts
+++ b/tests/ImportsSeparatedByEmptyRegex/imports-with-file-level-comments.ts
@@ -1,5 +1,6 @@
 //@ts-ignore
 // I am file top level comments
+
 import threeLevelRelativePath from "../../../threeLevelRelativePath";
 // I am stick to sameLevelRelativePath
 import sameLevelRelativePath from "./sameLevelRelativePath";

--- a/tests/ImportsSeparatedByEmptyRegex/imports-with-file-level-comments.ts
+++ b/tests/ImportsSeparatedByEmptyRegex/imports-with-file-level-comments.ts
@@ -10,7 +10,7 @@ import thirdParty from "third-party";
 import {
     random // inner comment
 } from './random';
-// trailing comment for import-random (export statement is code that will be sorted to below imports, and so doesn't have precedence over the import-comment-attachment rules!)
+// leading comment for export from random
 export {
     random // inner comment
 } from './random';

--- a/tests/ImportsSeparatedByEmptyRegex/imports-with-side-effect-imports.ts
+++ b/tests/ImportsSeparatedByEmptyRegex/imports-with-side-effect-imports.ts
@@ -1,4 +1,5 @@
 // I am top level comment in this file.
+
 import thirdParty0 from "third-party0";
 import something3 from "@core/something3";
 import thirdDisco0 from "third-disco0";

--- a/tests/ImportsSeparatedByEmptyRegex/imports-without-third-party.ts
+++ b/tests/ImportsSeparatedByEmptyRegex/imports-without-third-party.ts
@@ -1,4 +1,5 @@
 // I am top level comment
+
 import otherthing from "@core/otherthing";
 import abc from "@core/abc";
 // I am comment

--- a/tests/ImportsSeparatedIntoSideEffectGroups/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/ImportsSeparatedIntoSideEffectGroups/__snapshots__/ppsi.spec.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`imports-with-side-effect-imports.ts - typescript-verify > imports-with-side-effect-imports.ts 1`] = `
 // I am top level comment in this file.
+
 import thirdParty0 from "third-party0";
 import something3 from "@core/something3";
 import thirdDisco0 from "third-disco0";
@@ -41,6 +42,7 @@ import thirdDisco2 from "third-disco2";
 import thirdParty2 from "third-party2";
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // I am top level comment in this file.
+
 import thirdDisco0 from "third-disco0";
 import thirdParty0 from "third-party0";
 import otherthing3 from "@core/otherthing3";

--- a/tests/ImportsSeparatedIntoSideEffectGroups/imports-with-side-effect-imports.ts
+++ b/tests/ImportsSeparatedIntoSideEffectGroups/imports-with-side-effect-imports.ts
@@ -1,4 +1,5 @@
 // I am top level comment in this file.
+
 import thirdParty0 from "third-party0";
 import something3 from "@core/something3";
 import thirdDisco0 from "third-disco0";

--- a/tests/ImportsThirdParty/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/ImportsThirdParty/__snapshots__/ppsi.spec.ts.snap
@@ -60,6 +60,7 @@ export const a = 1;
 exports[`imports-with-comments.ts - typescript-verify > imports-with-comments.ts 1`] = `
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
+
 import './commands';
 
 // Comment
@@ -71,6 +72,7 @@ function add(a:number,b:number) {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
+
 import "./commands";
 
 // Comment
@@ -85,6 +87,7 @@ function add(a: number, b: number) {
 exports[`imports-with-comments-and-third-party.ts - typescript-verify > imports-with-comments-and-third-party.ts 1`] = `
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
+
 import './commands';
 import React from 'react';
 // Comment
@@ -96,6 +99,7 @@ function add(a:number,b:number) {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
+
 import "./commands";
 import React from "react";
 
@@ -111,6 +115,7 @@ function add(a: number, b: number) {
 exports[`imports-with-comments-on-top.ts - typescript-verify > imports-with-comments-on-top.ts 1`] = `
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
+
 import z from 'z';
 import threeLevelRelativePath from "../../../threeLevelRelativePath";
 import sameLevelRelativePath from "./sameLevelRelativePath";
@@ -131,6 +136,7 @@ function add(a:number,b:number) {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
+
 import abc from "@core/abc";
 import otherthing from "@core/otherthing";
 import qwerty from "@server/qwerty";
@@ -154,6 +160,7 @@ function add(a: number, b: number) {
 exports[`imports-with-file-level-comments.ts - typescript-verify > imports-with-file-level-comments.ts 1`] = `
 //@ts-ignore
 // I am file top level comments
+
 import threeLevelRelativePath from "../../../threeLevelRelativePath";
 // I am stick to sameLevelRelativePath
 import sameLevelRelativePath from "./sameLevelRelativePath";
@@ -188,6 +195,7 @@ function add(a:number,b:number) {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 //@ts-ignore
 // I am file top level comments
+
 import otherthing from "@core/otherthing";
 import something from "@server/something";
 import component from "@ui/hello";
@@ -257,6 +265,7 @@ function add(a: number, b: number) {
 
 exports[`imports-without-third-party.ts - typescript-verify > imports-without-third-party.ts 1`] = `
 // I am top level comment
+
 import otherthing from "@core/otherthing";
 import abc from "@core/abc";
 // I am comment
@@ -266,6 +275,7 @@ import fourLevelRelativePath from "../../../../fourLevelRelativePath";
 import something from "@server/something";
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // I am top level comment
+
 import abc from "@core/abc";
 import otherthing from "@core/otherthing";
 import something from "@server/something";
@@ -321,6 +331,7 @@ import './commands';
 // You can read more here:
 // https://on.cypress.io/configuration
 // ***********************************************************
+
 // Import commands.js using ES2015 syntax:
 import "./commands";
 

--- a/tests/ImportsThirdParty/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/ImportsThirdParty/__snapshots__/ppsi.spec.ts.snap
@@ -102,8 +102,8 @@ function add(a:number,b:number) {
 
 import "./commands";
 import React from "react";
-
 // Comment
+
 // Comment
 
 function add(a: number, b: number) {

--- a/tests/ImportsThirdParty/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/ImportsThirdParty/__snapshots__/ppsi.spec.ts.snap
@@ -170,7 +170,7 @@ import thirdParty from "third-party";
 import {
     random // inner comment
 } from './random';
-// leading comment
+// trailing comment for import-random (export statement is code that will be sorted to below imports, and so doesn't have precedence over the import-comment-attachment rules!)
 export {
     random // inner comment
 } from './random';
@@ -212,10 +212,10 @@ import oneLevelRelativePath from "../oneLevelRelativePath";
 import {
     random, // inner comment
 } from "./random";
+// trailing comment for import-random (export statement is code that will be sorted to below imports, and so doesn't have precedence over the import-comment-attachment rules!)
 // I am stick to sameLevelRelativePath
 import sameLevelRelativePath from "./sameLevelRelativePath";
 
-// leading comment
 export {
     random, // inner comment
 } from "./random";

--- a/tests/ImportsThirdParty/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/ImportsThirdParty/__snapshots__/ppsi.spec.ts.snap
@@ -102,8 +102,8 @@ function add(a:number,b:number) {
 
 import "./commands";
 import React from "react";
-// Comment
 
+// Comment
 // Comment
 
 function add(a: number, b: number) {
@@ -170,7 +170,7 @@ import thirdParty from "third-party";
 import {
     random // inner comment
 } from './random';
-// trailing comment for import-random (export statement is code that will be sorted to below imports, and so doesn't have precedence over the import-comment-attachment rules!)
+// leading comment for export from random
 export {
     random // inner comment
 } from './random';
@@ -212,10 +212,10 @@ import oneLevelRelativePath from "../oneLevelRelativePath";
 import {
     random, // inner comment
 } from "./random";
-// trailing comment for import-random (export statement is code that will be sorted to below imports, and so doesn't have precedence over the import-comment-attachment rules!)
 // I am stick to sameLevelRelativePath
 import sameLevelRelativePath from "./sameLevelRelativePath";
 
+// leading comment for export from random
 export {
     random, // inner comment
 } from "./random";

--- a/tests/ImportsThirdParty/imports-with-comments-and-third-party.ts
+++ b/tests/ImportsThirdParty/imports-with-comments-and-third-party.ts
@@ -1,5 +1,6 @@
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
+
 import './commands';
 import React from 'react';
 // Comment

--- a/tests/ImportsThirdParty/imports-with-comments-on-top.ts
+++ b/tests/ImportsThirdParty/imports-with-comments-on-top.ts
@@ -1,5 +1,6 @@
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
+
 import z from 'z';
 import threeLevelRelativePath from "../../../threeLevelRelativePath";
 import sameLevelRelativePath from "./sameLevelRelativePath";

--- a/tests/ImportsThirdParty/imports-with-comments.ts
+++ b/tests/ImportsThirdParty/imports-with-comments.ts
@@ -1,5 +1,6 @@
 // I am top level comment in this file.
 // I am second line of top level comment in this file.
+
 import './commands';
 
 // Comment

--- a/tests/ImportsThirdParty/imports-with-file-level-comments.ts
+++ b/tests/ImportsThirdParty/imports-with-file-level-comments.ts
@@ -10,7 +10,7 @@ import thirdParty from "third-party";
 import {
     random // inner comment
 } from './random';
-// leading comment
+// trailing comment for import-random (export statement is code that will be sorted to below imports, and so doesn't have precedence over the import-comment-attachment rules!)
 export {
     random // inner comment
 } from './random';

--- a/tests/ImportsThirdParty/imports-with-file-level-comments.ts
+++ b/tests/ImportsThirdParty/imports-with-file-level-comments.ts
@@ -1,5 +1,6 @@
 //@ts-ignore
 // I am file top level comments
+
 import threeLevelRelativePath from "../../../threeLevelRelativePath";
 // I am stick to sameLevelRelativePath
 import sameLevelRelativePath from "./sameLevelRelativePath";

--- a/tests/ImportsThirdParty/imports-with-file-level-comments.ts
+++ b/tests/ImportsThirdParty/imports-with-file-level-comments.ts
@@ -10,7 +10,7 @@ import thirdParty from "third-party";
 import {
     random // inner comment
 } from './random';
-// trailing comment for import-random (export statement is code that will be sorted to below imports, and so doesn't have precedence over the import-comment-attachment rules!)
+// leading comment for export from random
 export {
     random // inner comment
 } from './random';

--- a/tests/ImportsThirdParty/imports-without-third-party.ts
+++ b/tests/ImportsThirdParty/imports-without-third-party.ts
@@ -1,4 +1,5 @@
 // I am top level comment
+
 import otherthing from "@core/otherthing";
 import abc from "@core/abc";
 // I am comment

--- a/tests/RemoveStatementsFromOriginalCode/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/RemoveStatementsFromOriginalCode/__snapshots__/ppsi.spec.ts.snap
@@ -27,10 +27,8 @@ import { bar } from "a";
 
 function baz() {
 }~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/* foo */
-
 import { bar } from "a";
-import { foo } from "c";
+/* foo */ import { foo } from "c";
 
 function baz() {}
 

--- a/tests/RemoveStatementsFromOriginalCode/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/RemoveStatementsFromOriginalCode/__snapshots__/ppsi.spec.ts.snap
@@ -27,8 +27,9 @@ import { bar } from "a";
 
 function baz() {
 }~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-/* foo */
 import { bar } from "a";
+
+/* foo */
 import { foo } from "c";
 
 function baz() {}

--- a/tests/Vue/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/Vue/__snapshots__/ppsi.spec.ts.snap
@@ -3,6 +3,7 @@
 exports[`setup.vue - vue-verify > setup.vue 1`] = `
 <script setup>
 // I am top level comment in this file.
+
 import z from 'z';
 import threeLevelRelativePath from "../../../threeLevelRelativePath";
 import sameLevelRelativePath from "./sameLevelRelativePath";
@@ -27,6 +28,7 @@ function add(a,b) {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <script setup>
 // I am top level comment in this file.
+
 import thirdParty from "third-party";
 import { defineComponent } from "vue";
 import z from "z";
@@ -59,6 +61,7 @@ function add(a, b) {
 exports[`sfc.vue - vue-verify > sfc.vue 1`] = `
 <script>
 // I am top level comment in this file.
+
 import z from 'z';
 import threeLevelRelativePath from "../../../threeLevelRelativePath";
 import sameLevelRelativePath from "./sameLevelRelativePath";
@@ -81,6 +84,7 @@ export default defineComponent({
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <script>
 // I am top level comment in this file.
+
 import thirdParty from "third-party";
 import { defineComponent } from "vue";
 import z from "z";
@@ -110,6 +114,7 @@ export default defineComponent({});
 exports[`ts.vue - vue-verify > ts.vue 1`] = `
 <script lang="ts">
 // I am top level comment in this file.
+
 import z from 'z';
 import threeLevelRelativePath from "../../../threeLevelRelativePath";
 import sameLevelRelativePath from "./sameLevelRelativePath";
@@ -132,6 +137,7 @@ export default defineComponent({
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <script lang="ts">
 // I am top level comment in this file.
+
 import thirdParty from "third-party";
 import { defineComponent } from "vue";
 import z from "z";
@@ -161,6 +167,7 @@ export default defineComponent({});
 exports[`tsx.vue - vue-verify > tsx.vue 1`] = `
 <script lang="tsx">
 // I am top level comment in this file.
+
 import z from 'z';
 import threeLevelRelativePath from "../../../threeLevelRelativePath";
 import sameLevelRelativePath from "./sameLevelRelativePath";
@@ -186,6 +193,7 @@ export default defineComponent({
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <script lang="tsx">
 // I am top level comment in this file.
+
 import thirdParty from "third-party";
 import { defineComponent } from "vue";
 import z from "z";

--- a/tests/Vue/setup.vue
+++ b/tests/Vue/setup.vue
@@ -1,5 +1,6 @@
 <script setup>
 // I am top level comment in this file.
+
 import z from 'z';
 import threeLevelRelativePath from "../../../threeLevelRelativePath";
 import sameLevelRelativePath from "./sameLevelRelativePath";

--- a/tests/Vue/sfc.vue
+++ b/tests/Vue/sfc.vue
@@ -1,5 +1,6 @@
 <script>
 // I am top level comment in this file.
+
 import z from 'z';
 import threeLevelRelativePath from "../../../threeLevelRelativePath";
 import sameLevelRelativePath from "./sameLevelRelativePath";

--- a/tests/Vue/ts.vue
+++ b/tests/Vue/ts.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 // I am top level comment in this file.
+
 import z from 'z';
 import threeLevelRelativePath from "../../../threeLevelRelativePath";
 import sameLevelRelativePath from "./sameLevelRelativePath";

--- a/tests/Vue/tsx.vue
+++ b/tests/Vue/tsx.vue
@@ -1,5 +1,6 @@
 <script lang="tsx">
 // I am top level comment in this file.
+
 import z from 'z';
 import threeLevelRelativePath from "../../../threeLevelRelativePath";
 import sameLevelRelativePath from "./sameLevelRelativePath";

--- a/yarn.lock
+++ b/yarn.lock
@@ -363,13 +363,6 @@
   dependencies:
     "@types/lodash" "*"
 
-"@types/lodash.isequal@4.5.6":
-  version "4.5.6"
-  resolved "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.6.tgz"
-  integrity sha512-Ww4UGSe3DmtvLLJm2F16hDwEQSv7U0Rr8SujLUA2wHI2D2dm8kPu6Et+/y303LfjTIwSBKXB/YTUcAKpem/XEg==
-  dependencies:
-    "@types/lodash" "*"
-
 "@types/lodash@*":
   version "4.14.182"
   resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz"
@@ -762,11 +755,6 @@ lodash.clone@^4.5.0:
   version "4.5.0"
   resolved "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz"
   integrity sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=
-
-lodash.isequal@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz"
-  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
 
 lodash@^4.17.15:
   version "4.17.21"


### PR DESCRIPTION
Fixes #9
Fixes #54

While attempting to work on #9 I found a lot of gnarly edge cases \o/.

Turns out our previous comment-adjuster didn't work for most cases (indeed it thought it was mutating nodes when it was actually generating clean nodes that it was then throwing away 🤦🏻‍♂️, and what "correct" behavior we were seeing before was incredibly brittle and lucky).

I've now added a section to the README that talks about how it handles comments, but generally speaking here's a quick tl;dr: 
1. Comments at top of File and below last import (> 1 line separation) are now preserved in those positions instead of being moved around when the nearest import is re-sorted/merged/moved.
1. Single-line-comments on `ImportDeclaration` or some flavor of `ImportSpecifier` are properly sorted with their parent-node now!
1. "loose" comments generally attach to the next-subsequent `ImportDeclaration` or `ImportSpecifier`. This means that we can now have a leading comment directly before an import, and it will follow that import. **But** it also meant that a ton of our test-cases had "top-of-file" comments that were interpreted as being attached to the first import, so I patched those test-cases so there's a new-line.

I think the new rules are internally consistent, but I await your feedback!

Please help me with the wording in the README and/or feel free to rewrite it, or use the bullets here to improve the phrasing. I thought about hot-linking to exact examples (snapshots?), but I wasn't sure if that was a good idea. We could use &lt;details&gt; components to embed them directly in the readme?
