### PR TITLE
Update to latest versions of Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,9 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: ${{ matrix.node }}
-            - run: yarn --frozen-lockfile
+                  cache: 'yarn'
+                  cache-dependency-path: 'yarn.lock'
+            - run: yarn install --frozen-lockfile --non-interactive
             - name: Test
               run: yarn test
             - name: Check formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ jobs:
             matrix:
                 node: [14.x, 16.x, 18.x]
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v2
+            - uses: actions/checkout@v3
+            - uses: actions/setup-node@v3
               with:
                   node-version: ${{ matrix.node }}
             - run: yarn --frozen-lockfile

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: 'CodeQL'
 
 on:
     push:
-        branches: [master]
+        branches: [main]
     pull_request:
         # The branches below must be a subset of the branches above
-        branches: [master]
+        branches: [main]
     schedule:
         - cron: '37 7 * * 0'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             # Initializes the CodeQL tools for scanning.
             - name: Initialize CodeQL
-              uses: github/codeql-action/init@v1
+              uses: github/codeql-action/init@v2
               with:
                   languages: ${{ matrix.language }}
                   # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,6 @@ jobs:
             # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
             # If this step fails, then you should remove it and run the build manually (see below)
             - name: Autobuild
-              uses: github/codeql-action/autobuild@v1
 
             # ℹ️ Command-line programs to run using the OS shell.
             # 📚 https://git.io/JvXDl
@@ -65,6 +64,7 @@ jobs:
             #- run: |
             #   make bootstrap
             #   make release
+              uses: github/codeql-action/autobuild@v2
 
             - name: Perform CodeQL Analysis
-              uses: github/codeql-action/analyze@v1
+              uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,7 +33,6 @@ jobs:
             fail-fast: false
             matrix:
                 language: ['javascript']
-                # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
                 # Learn more about CodeQL language support at https://git.io/codeql-language-support
 
         steps:
@@ -45,25 +44,10 @@ jobs:
               uses: github/codeql-action/init@v2
               with:
                   languages: ${{ matrix.language }}
-                  # If you wish to specify custom queries, you can do so here or in a config file.
-                  # By default, queries listed here will override any specified in a config file.
-                  # Prefix the list here with "+" to use these queries and those in the config file.
-                  # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
             # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
             # If this step fails, then you should remove it and run the build manually (see below)
             - name: Autobuild
-
-            # ℹ️ Command-line programs to run using the OS shell.
-            # 📚 https://git.io/JvXDl
-
-            # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-            #    and modify them (or add more) to build your code if your project
-            #    uses a compiled language
-
-            #- run: |
-            #   make bootstrap
-            #   make release
               uses: github/codeql-action/autobuild@v2
 
             - name: Perform CodeQL Analysis


### PR DESCRIPTION
I noticed a deprecation warning in GitHub Actions run summaries:
```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-node@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```

Thankfully this is a trivial upgrade, I also cleaned up a few other related things in the workflow files!