### PR TITLE
Clean-up lodash.clone dep, as it serves no purpose

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,13 +58,11 @@
         "@babel/parser": "^7.21.8",
         "@babel/traverse": "^7.21.5",
         "@babel/types": "^7.21.5",
-        "lodash.clone": "^4.5.0",
         "semver": "^7.5.0"
     },
     "devDependencies": {
         "@types/babel__generator": "^7.6.4",
         "@types/babel__traverse": "^7.18.3",
-        "@types/lodash.clone": "4.5.7",
         "@types/node": "^18.15.13",
         "@types/prettier": "^2.7.2",
         "@types/semver": "^7.3.13",

--- a/src/utils/get-sorted-nodes-by-import-order.ts
+++ b/src/utils/get-sorted-nodes-by-import-order.ts
@@ -1,5 +1,3 @@
-import clone from 'lodash.clone';
-
 import {
     BUILTIN_MODULES,
     newLineNode,
@@ -14,13 +12,15 @@ import { getSortedNodesGroup } from './get-sorted-nodes-group';
  * This function returns the given nodes, sorted in the order as indicated by
  * the importOrder array from the given options.
  * The plugin considers these import nodes as local import declarations.
- * @param nodes A subset of all import nodes that should be sorted.
+ * @param originalNodes A subset (of all import nodes) that should be sorted.
  * @param options Options to influence the behavior of the sorting algorithm.
  */
-export const getSortedNodesByImportOrder: GetSortedNodes = (nodes, options) => {
+export const getSortedNodesByImportOrder: GetSortedNodes = (
+    originalNodes,
+    options,
+) => {
     let { importOrder } = options;
 
-    const originalNodes = nodes.map(clone);
     const finalNodes: ImportOrLine[] = [];
 
     if (!importOrder.includes(THIRD_PARTY_MODULES_SPECIAL_WORD)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -364,18 +364,6 @@
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.5.tgz#ae69bcbb1bebb68c4ac0b11e9d8ed04526b3562b"
   integrity sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==
 
-"@types/lodash.clone@4.5.7":
-  version "4.5.7"
-  resolved "https://registry.yarnpkg.com/@types/lodash.clone/-/lodash.clone-4.5.7.tgz#110e28a71b3328c24d367162f48ae6aa9dab1973"
-  integrity sha512-jugWYM+xBUQCpWbn7p6BSbf8bRMHtJYnEIGZYngbStaU0aN4VFgAAkGgsc+MtHuepBOmjyUGiGv+dHnQQIGLZA==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash@*":
-  version "4.14.194"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.194.tgz#b71eb6f7a0ff11bff59fc987134a093029258a76"
-  integrity sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g==
-
 "@types/node@*":
   version "20.1.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.1.2.tgz#8fd63447e3f99aba6c3168fd2ec4580d5b97886f"
@@ -746,11 +734,6 @@ local-pkg@^0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-0.4.3.tgz#0ff361ab3ae7f1c19113d9bb97b98b905dbc4963"
   integrity sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==
-
-lodash.clone@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.clone/-/lodash.clone-4.5.0.tgz#195870450f5a13192478df4bc3d23d2dea1907b6"
-  integrity sha512-GhrVeweiTD6uTmmn5hV/lzgCQhccwReIVRLHp7LT4SopOjqEZ5BbX8b5WWEtAKasjmy8hR7ZPwsYlxRCku5odg==
 
 lodash@^4.17.15:
   version "4.17.21"


### PR DESCRIPTION
I believe the usage of `lodash.clone` used to be more prevalent (and necessary). But at this point we only had 1-remaining call-site, and I traced it, and don't see any mutating methods along the way, so I'm relatively confident this isn't necessary.

I also tested `JSON.parse(JSON.stringify(…))` and that passed the tests too, so if we'd prefer to use that instead, I can do so, just let me know!