### PR TITLE
Preserve trailing comments on specifiers

### DIFF
--- a/src/utils/get-comment-registry.ts
+++ b/src/utils/get-comment-registry.ts
@@ -426,6 +426,14 @@ export function attachCommentsToOutputNodes(
                 ];
 
             ownerNode = lastSpecifier;
+
+            // Start the comment on the line below the owner, to avoid gaps
+            if (
+                comment.loc?.start.line !== undefined &&
+                ownerNode.loc?.end.line
+            ) {
+                comment.loc.start.line = ownerNode.loc?.end.line + 1;
+            }
         }
 
         if (!ownerNode) {

--- a/tests/ImportCommentsPreserved/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/ImportCommentsPreserved/__snapshots__/ppsi.spec.ts.snap
@@ -206,6 +206,12 @@ import {
 } from "c";
 
 import {
+    b4,
+    a4,
+    // @ts-expect-error
+} from "c2";
+
+import {
     b2,a2,
     // @ts-expect-error
 } from "b";
@@ -220,7 +226,6 @@ import {
 import {
     a1,
     b1,
-
     // @ts-expect-error
 } from "a";
 import {
@@ -229,5 +234,10 @@ import {
     // @ts-expect-error
 } from "b";
 import { a3, b3 } from /* @ts-expect-error*/ "c";
+import {
+    a4,
+    b4,
+    // @ts-expect-error
+} from "c2";
 
 `;

--- a/tests/ImportCommentsPreserved/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/ImportCommentsPreserved/__snapshots__/ppsi.spec.ts.snap
@@ -167,3 +167,37 @@ import {
 // Rest of file below here
 
 `;
+
+exports[`import-comments-trailing-specifier-comment-lost.ts - typescript-verify > import-comments-trailing-specifier-comment-lost.ts 1`] = `
+import {
+    b3,
+    a3,
+    /* @ts-expect-error*/
+} from "c";
+
+import {
+    b2,a2,
+    // @ts-expect-error
+} from "b";
+
+import {
+    b1,
+    a1,
+
+    // @ts-expect-error
+} from "a";
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import {
+    a1,
+    b1,
+
+    // @ts-expect-error
+} from "a";
+import {
+    a2,
+    b2,
+    // @ts-expect-error
+} from "b";
+import { a3, b3 } from /* @ts-expect-error*/ "c";
+
+`;

--- a/tests/ImportCommentsPreserved/import-comments-trailing-specifier-comment-lost.ts
+++ b/tests/ImportCommentsPreserved/import-comments-trailing-specifier-comment-lost.ts
@@ -5,6 +5,12 @@ import {
 } from "c";
 
 import {
+    b4,
+    a4,
+    // @ts-expect-error
+} from "c2";
+
+import {
     b2,a2,
     // @ts-expect-error
 } from "b";

--- a/tests/ImportCommentsPreserved/import-comments-trailing-specifier-comment-lost.ts
+++ b/tests/ImportCommentsPreserved/import-comments-trailing-specifier-comment-lost.ts
@@ -1,0 +1,17 @@
+import {
+    b3,
+    a3,
+    /* @ts-expect-error*/
+} from "c";
+
+import {
+    b2,a2,
+    // @ts-expect-error
+} from "b";
+
+import {
+    b1,
+    a1,
+
+    // @ts-expect-error
+} from "a";


### PR DESCRIPTION
Fixes #79

Trailing comments on specifiers don't get automatically saved like top-level ones do.  This ensures that such comments are not lost


Before:
```ts
import {
    b2,a2,
    // @ts-expect-error
} from "b";

import {
    b1,
    a1,

    // @ts-expect-error
} from "a";
```
After
```ts
import {
    a1,
    b1,
    // @ts-expect-error
} from "a";
import {
    a2,
    b2,
    // @ts-expect-error
} from "b";
```