### PR TITLE
Update our Default Sort Order builtins, (thirdparty & absolute paths), relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,17 @@ A collection of Regular expressions in string format.
 "importOrder": ["^@core/(.*)$", "^@server/(.*)$", "^@ui/(.*)$", "^[./]"],
 ```
 
-_Default:_ `[]`
+_Default:_
 
-By default, this plugin will not move any imports. To separate third party from relative imports, use `["^[./]"]`. This will become the default in the next major version.
+```js
+[
+            // built-ins are implicitly first
+    '<THIRD_PARTY_MODULES>',
+    '^[.]', // relative imports
+],
+```
+
+By default, this plugin sorts as documented on the line above.
 
 The plugin moves the third party imports to the top which are not part of the `importOrder` list.
 To move the third party imports at desired place, you can use `<THIRD_PARTY_MODULES>` to assign third party imports to the appropriate position:

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { parsers as flowParsers } from 'prettier/parser-flow';
 import { parsers as htmlParsers } from 'prettier/parser-html';
 import { parsers as typescriptParsers } from 'prettier/parser-typescript';
 
+import { THIRD_PARTY_MODULES_SPECIAL_WORD } from './constants';
 import { defaultPreprocessor } from './preprocessors/default';
 import { vuePreprocessor } from './preprocessors/vue';
 import type { PrettierOptions } from './types';
@@ -25,8 +26,17 @@ export const options: Record<
         type: 'path',
         category: 'Global',
         array: true,
-        default: [{ value: [] }],
-        description: 'Provide an order to sort imports.',
+        default: [
+            {
+                value: [
+                    // built-ins are implicitly first
+                    THIRD_PARTY_MODULES_SPECIAL_WORD,
+                    '^[.]', // relative imports
+                ],
+            },
+        ],
+        description:
+            'Provide an order to sort imports. [built-ins are always implicitly first]',
     },
     importOrderParserPlugins: {
         type: 'path',

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,14 +29,14 @@ export const options: Record<
         default: [
             {
                 value: [
-                    // built-ins are implicitly first
-                    THIRD_PARTY_MODULES_SPECIAL_WORD,
+                    // node.js built-ins are always first
+                    THIRD_PARTY_MODULES_SPECIAL_WORD, // Everything not matching relative imports
                     '^[.]', // relative imports
                 ],
             },
         ],
         description:
-            'Provide an order to sort imports. [built-ins are always implicitly first]',
+            'Provide an order to sort imports. [node.js built-ins are always first]',
     },
     importOrderParserPlugins: {
         type: 'path',


### PR DESCRIPTION
Fixes #76 

```js
[
            // built-ins are implicitly first
    '<THIRD_PARTY_MODULES>', // Actually means "all things that aren't otherwise matched" aka THIRD_PARTY_IMPORTS & Absolute Path Imports
    '^[.]', // relative imports
],
```

- There's no way to separate THIRD_PARTY_MODULES and absolute-imports currently
- We can discuss a renaming for THIRD_PARTY_MODULES later