### PR TITLE
Slight reorganization around top-of-file comments

### DIFF
--- a/src/utils/__tests__/get-comment-registry.spec.ts
+++ b/src/utils/__tests__/get-comment-registry.spec.ts
@@ -15,19 +15,6 @@ import {
 
 describe('getCommentRegistryFromImportDeclarations', () => {
     test('is empty if provided no comments or no first-import', () => {
-        expect(getCommentRegistryFromImportDeclarations({} as any)).toEqual([]);
-        expect(
-            getCommentRegistryFromImportDeclarations({
-                firstImport: null as any,
-                outputNodes: [],
-            }),
-        ).toEqual([]);
-        expect(
-            getCommentRegistryFromImportDeclarations({
-                firstImport: null as any,
-                outputNodes: [emptyStatement() as any],
-            }),
-        ).toEqual([]);
         expect(
             getCommentRegistryFromImportDeclarations({
                 firstImport: emptyStatement() as any,
@@ -40,24 +27,10 @@ describe('getCommentRegistryFromImportDeclarations', () => {
 describe('attachCommentsToOutputNodes', () => {
     test('throws when missing inputs', () => {
         expect(() =>
-            attachCommentsToOutputNodes(null as any, null as any, null as any),
-        ).toThrow(
-            new Error(
-                'Fatal Internal Error: Expected a list of commentEntriesFromRegistry',
-            ),
-        );
-        expect(() =>
             attachCommentsToOutputNodes([], [], emptyStatement() as any),
         ).toThrow(
             new Error(
                 "Fatal Internal Error: Can't attach comments to empty output",
-            ),
-        );
-        expect(() =>
-            attachCommentsToOutputNodes([], [{} as any], null as any),
-        ).toThrow(
-            new Error(
-                "Fatal Internal Error: Can't attach comments if there was no firstImport",
             ),
         );
     });

--- a/src/utils/__tests__/get-comment-registry.spec.ts
+++ b/src/utils/__tests__/get-comment-registry.spec.ts
@@ -1,16 +1,16 @@
 import {
     emptyStatement,
-    type ImportDeclaration,
-    type CommentBlock,
     stringLiteral,
+    type CommentBlock,
+    type ImportDeclaration,
 } from '@babel/types';
-import { expect, test, describe } from 'vitest';
+import { describe, expect, test } from 'vitest';
 
 import {
-    getCommentRegistryFromImportDeclarations,
     attachCommentsToOutputNodes,
-    testingOnlyExports,
     CommentAssociation,
+    getCommentRegistryFromImportDeclarations,
+    testingOnlyExports,
 } from '../get-comment-registry';
 
 describe('getCommentRegistryFromImportDeclarations', () => {

--- a/src/utils/__tests__/get-comment-registry.spec.ts
+++ b/src/utils/__tests__/get-comment-registry.spec.ts
@@ -1,0 +1,106 @@
+import {
+    emptyStatement,
+    type ImportDeclaration,
+    type CommentBlock,
+    stringLiteral,
+} from '@babel/types';
+import { expect, test, describe } from 'vitest';
+
+import {
+    getCommentRegistryFromImportDeclarations,
+    attachCommentsToOutputNodes,
+    testingOnlyExports,
+    CommentAssociation,
+} from '../get-comment-registry';
+
+describe('getCommentRegistryFromImportDeclarations', () => {
+    test('is empty if provided no comments or no first-import', () => {
+        expect(getCommentRegistryFromImportDeclarations({} as any)).toEqual([]);
+        expect(
+            getCommentRegistryFromImportDeclarations({
+                firstImport: null as any,
+                outputNodes: [],
+            }),
+        ).toEqual([]);
+        expect(
+            getCommentRegistryFromImportDeclarations({
+                firstImport: null as any,
+                outputNodes: [emptyStatement() as any],
+            }),
+        ).toEqual([]);
+        expect(
+            getCommentRegistryFromImportDeclarations({
+                firstImport: emptyStatement() as any,
+                outputNodes: [],
+            }),
+        ).toEqual([]);
+    });
+});
+
+describe('attachCommentsToOutputNodes', () => {
+    test('throws when missing inputs', () => {
+        expect(() =>
+            attachCommentsToOutputNodes(null as any, null as any, null as any),
+        ).toThrow(
+            new Error(
+                'Fatal Internal Error: Expected a list of commentEntriesFromRegistry',
+            ),
+        );
+        expect(() =>
+            attachCommentsToOutputNodes([], [], emptyStatement() as any),
+        ).toThrow(
+            new Error(
+                "Fatal Internal Error: Can't attach comments to empty output",
+            ),
+        );
+        expect(() =>
+            attachCommentsToOutputNodes([], [{} as any], null as any),
+        ).toThrow(
+            new Error(
+                "Fatal Internal Error: Can't attach comments if there was no firstImport",
+            ),
+        );
+    });
+    test('does not inject an EmptyStatement if there are no top-of-file comments', () => {
+        const firstImport = {
+            type: 'ImportDeclaration',
+            specifiers: [],
+            source: stringLiteral('foo'),
+        } as ImportDeclaration;
+        const outputNodes = [firstImport];
+
+        attachCommentsToOutputNodes([], outputNodes, firstImport);
+
+        expect(outputNodes[0].type).not.toEqual('EmptyStatement');
+    });
+    test("injects an EmptyStatement if there's a top-of-file comment", () => {
+        const firstImport = {
+            type: 'ImportDeclaration',
+            specifiers: [],
+            source: stringLiteral('foo'),
+        } as ImportDeclaration;
+        const comment = {
+            type: 'CommentBlock',
+            value: '@prettier',
+        } as CommentBlock;
+        const outputNodes = [firstImport];
+
+        attachCommentsToOutputNodes(
+            [
+                {
+                    needsTopOfFileOwner: true,
+                    comment,
+                    ownerIsSpecifier: false,
+                    commentId: testingOnlyExports.nodeId(comment),
+                    owner: firstImport,
+                    association: CommentAssociation.trailing,
+                    processingPriority: 0,
+                },
+            ],
+            outputNodes,
+            firstImport,
+        );
+
+        expect(outputNodes[0].type).toEqual('EmptyStatement');
+    });
+});

--- a/src/utils/adjust-comments-on-sorted-nodes.ts
+++ b/src/utils/adjust-comments-on-sorted-nodes.ts
@@ -15,15 +15,15 @@ import {
  * @returns A copied and adjusted set of nodes, containing comments
  */
 export const adjustCommentsOnSortedNodes = (
-    originalDeclarationNodes: ImportDeclaration[],
-    finalNodes: ImportOrLine[],
+    originalDeclarationNodes: readonly ImportDeclaration[],
+    finalNodes: readonly ImportOrLine[],
 ) => {
     const outputNodes: ImportDeclaration[] = finalNodes.filter(
         (n) => n.type === 'ImportDeclaration',
     ) as ImportDeclaration[];
     if (originalDeclarationNodes.length === 0 || outputNodes.length === 0) {
         // Nothing to do, because there are no ImportDeclarations!
-        return finalNodes;
+        return [...finalNodes];
     }
 
     const firstImport = originalDeclarationNodes[0];

--- a/src/utils/get-all-comments-from-nodes.ts
+++ b/src/utils/get-all-comments-from-nodes.ts
@@ -8,7 +8,7 @@ import type {
 import { SomeSpecifier } from '../types';
 
 export const getAllCommentsFromNodes = (
-    nodes: (Directive | Statement | SomeSpecifier)[],
+    nodes: readonly (Directive | Statement | SomeSpecifier)[],
 ) =>
     nodes.reduce((acc, node) => {
         if (

--- a/src/utils/get-comment-registry.ts
+++ b/src/utils/get-comment-registry.ts
@@ -244,7 +244,7 @@ export const getCommentRegistryFromImportDeclarations = ({
     /** Constructed Output Nodes */
     outputNodes: ImportDeclaration[];
 }) => {
-    if (outputNodes.length === 0 || !firstImport) {
+    if (outputNodes?.length === 0 || !firstImport) {
         return [];
     }
 
@@ -369,7 +369,12 @@ export function attachCommentsToOutputNodes(
     /** Original declaration, not the re-sorted output-node! */
     firstImport: ImportDeclaration,
 ) {
-    if (outputNodes.length === 0) {
+    if (!Array.isArray(commentEntriesFromRegistry)) {
+        throw new Error(
+            'Fatal Internal Error: Expected a list of commentEntriesFromRegistry',
+        );
+    }
+    if (outputNodes == null || outputNodes.length === 0) {
         // attachCommentsToOutputNodes implies that there's at least one output node so this shouldn't happen
         throw new Error(
             "Fatal Internal Error: Can't attach comments to empty output",
@@ -539,3 +544,6 @@ function getHeightOfLeadingComments(node: ImportOrLine) {
     }
     return 0;
 }
+export const testingOnlyExports = {
+    nodeId,
+};

--- a/src/utils/get-comment-registry.ts
+++ b/src/utils/get-comment-registry.ts
@@ -242,9 +242,10 @@ export const getCommentRegistryFromImportDeclarations = ({
     firstImport: ImportDeclaration;
 
     /** Constructed Output Nodes */
-    outputNodes: ImportDeclaration[];
-}) => {
-    if (outputNodes?.length === 0 || !firstImport) {
+    outputNodes: readonly ImportDeclaration[];
+}): readonly CommentEntry[] => {
+    if (outputNodes.length === 0) {
+        // Nothing to do if there are no outputs
         return [];
     }
 
@@ -364,27 +365,18 @@ export const getCommentRegistryFromImportDeclarations = ({
 };
 
 export function attachCommentsToOutputNodes(
-    commentEntriesFromRegistry: CommentEntry[],
+    commentEntriesFromRegistry: readonly CommentEntry[],
     outputNodes: ImportOrLine[],
     /** Original declaration, not the re-sorted output-node! */
     firstImport: ImportDeclaration,
 ) {
-    if (!Array.isArray(commentEntriesFromRegistry)) {
-        throw new Error(
-            'Fatal Internal Error: Expected a list of commentEntriesFromRegistry',
-        );
-    }
-    if (outputNodes == null || outputNodes.length === 0) {
+    if (outputNodes.length === 0) {
         // attachCommentsToOutputNodes implies that there's at least one output node so this shouldn't happen
         throw new Error(
             "Fatal Internal Error: Can't attach comments to empty output",
         );
     }
-    if (firstImport == null) {
-        throw new Error(
-            "Fatal Internal Error: Can't attach comments if there was no firstImport",
-        );
-    }
+
     const newFirstImport = outputNodes[0];
 
     /** Store a mapping of Specifier to ImportDeclaration */

--- a/src/utils/get-comment-registry.ts
+++ b/src/utils/get-comment-registry.ts
@@ -189,6 +189,7 @@ const attachCommentsToRegistryMap = ({
                 deferredCommentClaims.push({
                     ...commentEntry,
                     needsTopOfFileOwner: true,
+                    association: CommentAssociation.trailing, // For top-of-file, always use trailing to preserve trailing blank line if present
                     processingPriority:
                         commentEntry.processingPriority +
                         DeferredCommentClaimPriorityAdjustment.leadingAboveAllImports,
@@ -379,12 +380,14 @@ export function attachCommentsToOutputNodes(
             "Fatal Internal Error: Can't attach comments if there was no firstImport",
         );
     }
+    const newFirstImport = outputNodes[0];
 
     /** Store a mapping of Specifier to ImportDeclaration */
     const parentNodeId = (specifier: SomeSpecifier) =>
         `parent::${nodeId(specifier)}`;
 
     const outputRegistry = new Map<string, ImportRelated>();
+    // Collect entries for every declaration, specifier, and parent of specifier in a single table for mapping
     for (const outputNode of outputNodes) {
         outputRegistry.set(nodeId(outputNode), outputNode);
         if (outputNode.type === 'ImportDeclaration') {
@@ -395,7 +398,48 @@ export function attachCommentsToOutputNodes(
         }
     }
 
-    const newFirstImport = outputNodes[0];
+    let hasPatchedNewFirstImportLocation = false;
+    /**
+     * Put the first import in the right spot (where the original first import started).
+     *  Otherwise, comments at the top of the file will not be formatted correctly.
+     *
+     * This is a little tricky, because the new first import might have leading comments,
+     *  and we have to move the node and all comments the same distance
+     *
+     * This works since late 2022, Babel uses `loc` (if-present) to hint how to render for some cases.
+     */
+    const patchNewFirstImportLocationOnlyOnce = () => {
+        if (!hasPatchedNewFirstImportLocation) {
+            return;
+        }
+
+        const commentHeight = getHeightOfLeadingComments(newFirstImport);
+        const originalLoc = newFirstImport.loc;
+        if (firstImport.loc && originalLoc) {
+            newFirstImport.loc = {
+                start: {
+                    ...firstImport.loc?.start,
+                    line: firstImport.loc?.start.line + commentHeight,
+                },
+                end: {
+                    ...firstImport.loc?.end,
+                    line: firstImport.loc?.end.line + commentHeight,
+                },
+            };
+            const moveDist =
+                originalLoc.start.line - newFirstImport.loc.start.line;
+
+            for (const commentType of orderedCommentKeysToRegister) {
+                newFirstImport[commentType]?.forEach((c) => {
+                    if (c.loc) {
+                        c.loc.start.line -= moveDist;
+                        c.loc.end.line -= moveDist;
+                    }
+                });
+            }
+        }
+        hasPatchedNewFirstImportLocation = true;
+    };
 
     for (const commentEntry of commentEntriesFromRegistry) {
         const {
@@ -406,44 +450,9 @@ export function attachCommentsToOutputNodes(
             needsLastSpecifierOwner,
         } = commentEntry;
 
-        if (needsTopOfFileOwner && outputNodes[0].type !== 'EmptyStatement') {
-            // Put in a dummy empty statement to attach top-of-file-comments to if one was not provided
-            const dummy = emptyStatement();
-            dummy.loc = {
-                start: { line: 0, column: 0 },
-                end: { line: 0, column: 0 },
-            };
-            outputNodes.unshift(dummy);
-
-            // Put the first import in the right spot, where the original first import started
-            // Otherwise, comments at the top of the file will not be formatted correctly.
-            // This is a little tricky, because the new first import might have leading comments,
-            // and we have to move the node and all comments the same distance
-            const commentHeight = getHeightOfLeadingComments(newFirstImport);
-            const originalLoc = newFirstImport.loc;
-            if (firstImport.loc && originalLoc) {
-                newFirstImport.loc = {
-                    start: {
-                        ...firstImport.loc?.start,
-                        line: firstImport.loc?.start.line + commentHeight,
-                    },
-                    end: {
-                        ...firstImport.loc?.end,
-                        line: firstImport.loc?.end.line + commentHeight,
-                    },
-                };
-                const moveDist =
-                    originalLoc.start.line - newFirstImport.loc.start.line;
-
-                for (const commentType of orderedCommentKeysToRegister) {
-                    newFirstImport[commentType]?.forEach((c) => {
-                        if (c.loc) {
-                            c.loc.start.line -= moveDist;
-                            c.loc.end.line -= moveDist;
-                        }
-                    });
-                }
-            }
+        if (needsTopOfFileOwner) {
+            ensureEmptyStatementAtFront(outputNodes);
+            patchNewFirstImportLocationOnlyOnce();
         }
 
         let ownerNode = needsTopOfFileOwner
@@ -451,6 +460,7 @@ export function attachCommentsToOutputNodes(
             : outputRegistry.get(nodeId(owner));
 
         if (needsLastSpecifierOwner) {
+            // get the owner (a specifier) and find its declaration node
             const parentDeclaration = outputRegistry.get(
                 parentNodeId(owner as SomeSpecifier),
             ) as ImportDeclaration | undefined;
@@ -463,6 +473,7 @@ export function attachCommentsToOutputNodes(
                     "Fatal Internal Error: Couldn't find parent declaration for a specifier",
                 );
             }
+            // Select the last specifier in the declaration
             const lastSpecifier =
                 parentDeclaration.specifiers[
                     parentDeclaration.specifiers.length - 1
@@ -484,8 +495,8 @@ export function attachCommentsToOutputNodes(
             throw new Error("Fatal Internal Error: Couldn't find owner node");
         }
 
-        // // Since we mucked with the loc of the newFirstImport, we need to be careful to
-        // // keep its comments in the right place, so adjust their loc too
+        // Since we mucked with the loc of the newFirstImport, we need to be careful to
+        //  keep its comments in the right place, so adjust their loc too
         if (
             ownerNode === newFirstImport &&
             association !== CommentAssociation.leading &&
@@ -496,17 +507,24 @@ export function attachCommentsToOutputNodes(
             comment.loc.start.line = ownerNode.loc.start.line;
         }
 
-        // addComments(ownerNode, association, [comment]);
-        // using Babel's addComments will reverse the comments if you iteratively attach them, so push them directly
-        const commentType = needsTopOfFileOwner
-            ? 'trailingComments' // use trailing comments to preserve trailing blank line if present
-            : CommentAssociationByValue[association];
-        const commentCollection = (ownerNode[commentType] =
-            ownerNode[commentType] || []);
+        // addComments(ownerNode, association, [comment]); -- using Babel's addComments will reverse the comments if you iteratively attach them, so push them directly
+        const attachment = CommentAssociationByValue[association];
+        const commentCollection = (ownerNode[attachment] =
+            ownerNode[attachment] || []);
         (commentCollection as Comment[]).push(comment);
     }
 }
-
+function ensureEmptyStatementAtFront(outputNodes: ImportOrLine[]) {
+    if (outputNodes[0].type === 'EmptyStatement') {
+        return;
+    }
+    const dummy = emptyStatement();
+    dummy.loc = {
+        start: { line: 0, column: 0 },
+        end: { line: 0, column: 0 },
+    };
+    outputNodes.unshift(dummy);
+}
 function getHeightOfLeadingComments(node: ImportOrLine) {
     if (
         Array.isArray(node.leadingComments) &&
@@ -514,7 +532,10 @@ function getHeightOfLeadingComments(node: ImportOrLine) {
         node.leadingComments[0].loc &&
         node.loc
     ) {
-        return node.loc.start.line - node.leadingComments[0].loc.start.line;
+        return Math.max(
+            0, // Use Math.max to avoid negative heights (shouldn't be possible)
+            node.loc.start.line - node.leadingComments[0].loc.start.line,
+        );
     }
     return 0;
 }


### PR DESCRIPTION
I think this makes the code a little easier to follow.

I wasn't able to add an end-to-end integration test around "empty-statements-at-top-of-file" because you're right @IanVS, other layers prevent that from happening.

Instead I added a unit-test to assert the fatal-errors that we throw.