### PR TITLE
Prevent comment gap when re-arranging first import

### DIFF
--- a/src/utils/get-comment-registry.ts
+++ b/src/utils/get-comment-registry.ts
@@ -406,7 +406,7 @@ export function attachCommentsToOutputNodes(
      * This works since late 2022, Babel uses `loc` (if-present) to hint how to render for some cases.
      */
     const patchNewFirstImportLocationOnlyOnce = () => {
-        if (!hasPatchedNewFirstImportLocation) {
+        if (hasPatchedNewFirstImportLocation) {
             return;
         }
 

--- a/tests/ImportCommentsPreserved/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/ImportCommentsPreserved/__snapshots__/ppsi.spec.ts.snap
@@ -102,6 +102,21 @@ import { useState } from "react";
 
 `;
 
+exports[`import-comments-no-top-gap.ts - typescript-verify > import-comments-no-top-gap.ts 1`] = `
+/**
+ * @prettier
+ */
+import { requireValue } from './utils/require/requireValue';
+import { fooValue } from './foo';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/**
+ * @prettier
+ */
+import { fooValue } from "./foo";
+import { requireValue } from "./utils/require/requireValue";
+
+`;
+
 exports[`import-comments-outer-comments-block-comments.ts - typescript-verify > import-comments-outer-comments-block-comments.ts 1`] = `
 // Loose leading comment before imports (should not be dragged down with B)
 

--- a/tests/ImportCommentsPreserved/import-comments-no-top-gap.ts
+++ b/tests/ImportCommentsPreserved/import-comments-no-top-gap.ts
@@ -1,0 +1,5 @@
+/**
+ * @prettier
+ */
+import { requireValue } from './utils/require/requireValue';
+import { fooValue } from './foo';


### PR DESCRIPTION
This should address https://github.com/IanVS/prettier-plugin-sort-imports/issues/54#issuecomment-1548967488.

Note, we don't currently have a way to _force_ or _remove_ a line at the top, under top-of-file comments, but I think this is okay.  We preserve whatever the user had before, which seems fine.  We can re-evaluate in the future if we hear from users.