### PR TITLE
Failing tests for comments on runtime code within imports

### DIFF
--- a/tests/ImportCommentsPreserved/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/ImportCommentsPreserved/__snapshots__/ppsi.spec.ts.snap
@@ -307,3 +307,41 @@ import {
 } from "d_proving_all_specifier_blank_lines_get_removed";
 
 `;
+
+exports[`inner-comment-on-declaration.ts - typescript-verify > inner-comment-on-declaration.ts 1`] = `
+const someRandomGlobal = "stuff"; // same-line comment on someRandomGlobal
+
+import * as fs from "fs";
+import * as path from "path";
+import shell from "shelljs";
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import * as fs from "fs";
+import * as path from "path";
+import shell from "shelljs";
+
+const someRandomGlobal = "stuff"; // same-line comment on someRandomGlobal
+
+`;
+
+exports[`leading-comments-on-declaration.ts - typescript-verify > leading-comments-on-declaration.ts 1`] = `
+#!/usr/bin/env ts-node
+
+// Leading comment on someRandomGlobal
+const someRandomGlobal = "stuff";
+
+import * as fs from "fs";
+import * as path from "path";
+import shell from "shelljs";
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#!/usr/bin/env ts-node
+
+import * as fs from "fs";
+import * as path from "path";
+import shell from "shelljs";
+
+// Leading comment on someRandomGlobal
+const someRandomGlobal = "stuff";
+
+`;

--- a/tests/ImportCommentsPreserved/inner-comment-on-declaration.ts
+++ b/tests/ImportCommentsPreserved/inner-comment-on-declaration.ts
@@ -1,0 +1,6 @@
+const someRandomGlobal = "stuff"; // same-line comment on someRandomGlobal
+
+import * as fs from "fs";
+import * as path from "path";
+import shell from "shelljs";
+

--- a/tests/ImportCommentsPreserved/leading-comments-on-declaration.ts
+++ b/tests/ImportCommentsPreserved/leading-comments-on-declaration.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env ts-node
+
+// Leading comment on someRandomGlobal
+const someRandomGlobal = "stuff";
+
+import * as fs from "fs";
+import * as path from "path";
+import shell from "shelljs";
+


### PR DESCRIPTION
We have trouble moving comments on runtime code within the imports, because we treat those as comments on the imports instead.

This is just a couple of failing tests, in case we have time to come back and work on this.