### PR TITLE
Support babel-ts parser

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,10 @@ export const parsers = {
         ...babelParsers.babel,
         preprocess: defaultPreprocessor,
     },
+    'babel-ts': {
+        ...babelParsers['babel-ts'],
+        preprocess: defaultPreprocessor,
+    },
     flow: {
         ...flowParsers.flow,
         preprocess: defaultPreprocessor,

--- a/tests/Babel-ts/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/Babel-ts/__snapshots__/ppsi.spec.ts.snap
@@ -1,0 +1,133 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`imports-with-comments.ts - babel-ts-verify > imports-with-comments.ts 1`] = `
+// I am top level comment in this file.
+
+import z from 'z';
+import threeLevelRelativePath from "../../../threeLevelRelativePath";
+import sameLevelRelativePath from "./sameLevelRelativePath";
+import thirdParty from "third-party";
+import oneLevelRelativePath from "../oneLevelRelativePath";
+import otherthing from "@core/otherthing";
+import abc from "@core/abc";
+import twoLevelRelativePath from "../../twoLevelRelativePath";
+import component from "@ui/hello";
+import fourLevelRelativePath from "../../../../fourLevelRelativePath";
+import something from "@server/something";
+import xyz from "@ui/xyz";
+
+function add(a,b) {
+  return a + b;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// I am top level comment in this file.
+
+import thirdParty from "third-party";
+import z from "z";
+import abc from "@core/abc";
+import otherthing from "@core/otherthing";
+import something from "@server/something";
+import component from "@ui/hello";
+import xyz from "@ui/xyz";
+import fourLevelRelativePath from "../../../../fourLevelRelativePath";
+import threeLevelRelativePath from "../../../threeLevelRelativePath";
+import twoLevelRelativePath from "../../twoLevelRelativePath";
+import oneLevelRelativePath from "../oneLevelRelativePath";
+import sameLevelRelativePath from "./sameLevelRelativePath";
+
+function add(a, b) {
+    return a + b;
+}
+
+`;
+
+exports[`imports-with-side-effect-imports.ts - babel-ts-verify > imports-with-side-effect-imports.ts 1`] = `
+// I am top level comment in this file.
+
+import thirdParty0 from "third-party0";
+import something3 from "@core/something3";
+import thirdDisco0 from "third-disco0";
+import otherthing3 from "@core/otherthing3";
+
+import "side-effect-z";
+
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import something0 from "@core/something0";
+import thirdDisco1 from "third-disco1";
+import otherthing0 from "@core/otherthing0";
+import sameLevelRelativePath3 from "./sameLevelRelativePath3";
+import thirdParty1 from "third-party1";
+import oneLevelRelativePath1 from "../oneLevelRelativePath1";
+import anotherOneLevelRelativePath1 from "../anotherOneLevelRelativePath1";
+
+import "side-effect-y3";
+import "side-effect-y1";
+import "side-effect-y2";
+
+import oneLevelRelativePath2 from "../oneLevelRelativePath2";
+import anotherOneLevelRelativePath2 from "../anotherOneLevelRelativePath2";
+import something2 from "@core/something2";
+import thirdParty3 from "third-party3";
+import anotherSameLevelRelativePath1 from "./anotherSameLevelRelativePath1";
+import sameLevelRelativePath1 from "./sameLevelRelativePath1";
+import otherthing2 from "@core/otherthing2";
+import thirdDisco3 from "third-disco3";
+
+import "side-effect-x";
+import anotherSameLevelRelativePath2 from "./anotherSameLevelRelativePath2";
+import sameLevelRelativePath2 from "./sameLevelRelativePath2";
+import something1 from "@core/something1";
+import oneLevelRelativePath3 from "../oneLevelRelativePath3";
+import anotherOneLevelRelativePath3 from "../anotherOneLevelRelativePath3";
+import otherthing1 from "@core/otherthing1";
+import thirdDisco2 from "third-disco2";
+import thirdParty2 from "third-party2";
+
+import { Component } from "@angular/core";
+
+function add(a,b) {
+  return a + b;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// I am top level comment in this file.
+
+import thirdDisco0 from "third-disco0";
+import thirdParty0 from "third-party0";
+import otherthing3 from "@core/otherthing3";
+import something3 from "@core/something3";
+import "side-effect-z";
+import thirdDisco1 from "third-disco1";
+import thirdParty1 from "third-party1";
+import otherthing0 from "@core/otherthing0";
+import something0 from "@core/something0";
+import anotherOneLevelRelativePath1 from "../anotherOneLevelRelativePath1";
+import oneLevelRelativePath1 from "../oneLevelRelativePath1";
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import sameLevelRelativePath3 from "./sameLevelRelativePath3";
+import "side-effect-y3";
+import "side-effect-y1";
+import "side-effect-y2";
+import thirdDisco3 from "third-disco3";
+import thirdParty3 from "third-party3";
+import otherthing2 from "@core/otherthing2";
+import something2 from "@core/something2";
+import anotherOneLevelRelativePath2 from "../anotherOneLevelRelativePath2";
+import oneLevelRelativePath2 from "../oneLevelRelativePath2";
+import anotherSameLevelRelativePath1 from "./anotherSameLevelRelativePath1";
+import sameLevelRelativePath1 from "./sameLevelRelativePath1";
+import "side-effect-x";
+import { Component } from "@angular/core";
+import thirdDisco2 from "third-disco2";
+import thirdParty2 from "third-party2";
+import otherthing1 from "@core/otherthing1";
+import something1 from "@core/something1";
+import anotherOneLevelRelativePath3 from "../anotherOneLevelRelativePath3";
+import oneLevelRelativePath3 from "../oneLevelRelativePath3";
+import anotherSameLevelRelativePath2 from "./anotherSameLevelRelativePath2";
+import sameLevelRelativePath2 from "./sameLevelRelativePath2";
+
+function add(a, b) {
+    return a + b;
+}
+
+`;

--- a/tests/Babel-ts/imports-with-comments.ts
+++ b/tests/Babel-ts/imports-with-comments.ts
@@ -1,0 +1,18 @@
+// I am top level comment in this file.
+
+import z from 'z';
+import threeLevelRelativePath from "../../../threeLevelRelativePath";
+import sameLevelRelativePath from "./sameLevelRelativePath";
+import thirdParty from "third-party";
+import oneLevelRelativePath from "../oneLevelRelativePath";
+import otherthing from "@core/otherthing";
+import abc from "@core/abc";
+import twoLevelRelativePath from "../../twoLevelRelativePath";
+import component from "@ui/hello";
+import fourLevelRelativePath from "../../../../fourLevelRelativePath";
+import something from "@server/something";
+import xyz from "@ui/xyz";
+
+function add(a,b) {
+  return a + b;
+}

--- a/tests/Babel-ts/imports-with-side-effect-imports.ts
+++ b/tests/Babel-ts/imports-with-side-effect-imports.ts
@@ -1,0 +1,46 @@
+// I am top level comment in this file.
+
+import thirdParty0 from "third-party0";
+import something3 from "@core/something3";
+import thirdDisco0 from "third-disco0";
+import otherthing3 from "@core/otherthing3";
+
+import "side-effect-z";
+
+import anotherSameLevelRelativePath3 from "./anotherSameLevelRelativePath3";
+import something0 from "@core/something0";
+import thirdDisco1 from "third-disco1";
+import otherthing0 from "@core/otherthing0";
+import sameLevelRelativePath3 from "./sameLevelRelativePath3";
+import thirdParty1 from "third-party1";
+import oneLevelRelativePath1 from "../oneLevelRelativePath1";
+import anotherOneLevelRelativePath1 from "../anotherOneLevelRelativePath1";
+
+import "side-effect-y3";
+import "side-effect-y1";
+import "side-effect-y2";
+
+import oneLevelRelativePath2 from "../oneLevelRelativePath2";
+import anotherOneLevelRelativePath2 from "../anotherOneLevelRelativePath2";
+import something2 from "@core/something2";
+import thirdParty3 from "third-party3";
+import anotherSameLevelRelativePath1 from "./anotherSameLevelRelativePath1";
+import sameLevelRelativePath1 from "./sameLevelRelativePath1";
+import otherthing2 from "@core/otherthing2";
+import thirdDisco3 from "third-disco3";
+
+import "side-effect-x";
+import anotherSameLevelRelativePath2 from "./anotherSameLevelRelativePath2";
+import sameLevelRelativePath2 from "./sameLevelRelativePath2";
+import something1 from "@core/something1";
+import oneLevelRelativePath3 from "../oneLevelRelativePath3";
+import anotherOneLevelRelativePath3 from "../anotherOneLevelRelativePath3";
+import otherthing1 from "@core/otherthing1";
+import thirdDisco2 from "third-disco2";
+import thirdParty2 from "third-party2";
+
+import { Component } from "@angular/core";
+
+function add(a,b) {
+  return a + b;
+}

--- a/tests/Babel-ts/ppsi.spec.ts
+++ b/tests/Babel-ts/ppsi.spec.ts
@@ -1,0 +1,5 @@
+import {run_spec} from '../../test-setup/run_spec';
+
+run_spec(__dirname, ["babel-ts"], {
+    importOrder: [ "<THIRD_PARTY_MODULES>", '^@core/(.*)$', '^@server/(.*)', '^@ui/(.*)$', '^[./]'],
+});


### PR DESCRIPTION
Restores compatibility with the latest version of `prettier-plugin-astro`.

Fixes https://github.com/IanVS/prettier-plugin-sort-imports/issues/96.

To confirm, I made this change in the `node_modules` of the project in the above issue, and confirmed that sorting began working correctly again.