### PR TITLE
Fix dollar sign ($) issue in Vue SFC

### DIFF
--- a/src/preprocessors/vue.ts
+++ b/src/preprocessors/vue.ts
@@ -84,6 +84,6 @@ function sortScript(
 
     return code.replace(
         content,
-        `\n${preprocessor(content, adjustedOptions)}\n`,
+        () => `\n${preprocessor(content, adjustedOptions)}\n`,
     );
 }

--- a/tests/Vue/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/Vue/__snapshots__/ppsi.spec.ts.snap
@@ -149,6 +149,10 @@ import { defineComponent } from 'vue'
 function add(a,b) {
   return a + b;
 }
+
+const number = 500;
+const dollarSign = '$';
+const dollarPrefixed =\`\\$\${number}\`;
 </script>
 
 <template>
@@ -179,6 +183,10 @@ import sameLevelRelativePath from "./sameLevelRelativePath";
 function add(a, b) {
     return a + b;
 }
+
+const number = 500;
+const dollarSign = "$";
+const dollarPrefixed = \`\\$\${number}\`;
 </script>
 
 <template>

--- a/tests/Vue/setup.vue
+++ b/tests/Vue/setup.vue
@@ -17,6 +17,10 @@ import { defineComponent } from 'vue'
 function add(a,b) {
   return a + b;
 }
+
+const number = 500;
+const dollarSign = '$';
+const dollarPrefixed =`\$${number}`;
 </script>
 
 <template>


### PR DESCRIPTION
Fixes #100

When replacing a string if the provided replacement is a string it will replace the original string using pattern matching. In the vue preprocessor, the `$` in the code is seen as a regex pattern. Passing a function as a replacement escapes that issue.