### PR TITLE
Account for missing filepath

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -26,11 +26,10 @@ export interface PrettierOptions
 /** Subset of options that need to be normalized, or affect normalization */
 export type NormalizableOptions = Pick<
     PrettierOptions,
-    | 'importOrder'
-    | 'importOrderParserPlugins'
-    | 'importOrderTypeScriptVersion'
-    | 'filepath'
->;
+    'importOrder' | 'importOrderParserPlugins' | 'importOrderTypeScriptVersion'
+> &
+    // filepath can be undefined when running prettier via the api on text input
+    Pick<Partial<PrettierOptions>, 'filepath'>;
 
 export type ChunkType = typeof chunkTypeOther | typeof chunkTypeUnsortable;
 export type FlavorType =

--- a/src/utils/__tests__/normalize-plugin-options.spec.ts
+++ b/src/utils/__tests__/normalize-plugin-options.spec.ts
@@ -194,4 +194,23 @@ describe('examineAndNormalizePluginOptions', () => {
             provideGapAfterTopOfFileComments: false,
         });
     });
+    test('it should not have a problem with a missing filepath', () => {
+        expect(
+            examineAndNormalizePluginOptions({
+                importOrder: [],
+                importOrderParserPlugins: [],
+                importOrderTypeScriptVersion: '1.0.0',
+                filepath: undefined,
+            } as NormalizableOptions),
+        ).toEqual({
+            hasAnyCustomGroupSeparatorsInImportOrder: false,
+            importOrder: [
+                BUILTIN_MODULES_REGEX_STR,
+                THIRD_PARTY_MODULES_SPECIAL_WORD,
+            ],
+            importOrderCombineTypeAndValueImports: true,
+            plugins: [],
+            provideGapAfterTopOfFileComments: false,
+        });
+    });
 });

--- a/src/utils/normalize-plugin-options.ts
+++ b/src/utils/normalize-plugin-options.ts
@@ -88,7 +88,7 @@ export function examineAndNormalizePluginOptions(
 
     let plugins = getExperimentalParserPlugins(importOrderParserPlugins);
     // Do not inject jsx plugin for non-jsx ts files
-    if (filepath.endsWith('.ts')) {
+    if (filepath?.endsWith('.ts')) {
         plugins = plugins.filter((p) => p !== 'jsx');
     }
 


### PR DESCRIPTION
Fixes https://github.com/IanVS/prettier-plugin-sort-imports/issues/103

We were using a type which indicated that filepath would not be undefined, but perhaps that's the wrong type to be using.  At any rate, I've adjusted our code to handle a missing filepath when prettier is used on text rather than a file.

The types we are using: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/748cf8849b6c67026557632fc1fe2ebbbef0700c/types/prettier/index.d.ts#L288