### PR TITLE
Bugfix: handle case where `filepath` isn't available due to programatic access of prettier

### DIFF
--- a/src/utils/normalize-plugin-options.ts
+++ b/src/utils/normalize-plugin-options.ts
@@ -88,7 +88,7 @@ export function examineAndNormalizePluginOptions(
 
     let plugins = getExperimentalParserPlugins(importOrderParserPlugins);
     // Do not inject jsx plugin for non-jsx ts files
-    if (filepath.endsWith('.ts')) {
+    if (filepath?.endsWith('.ts')) {
         plugins = plugins.filter((p) => p !== 'jsx');
     }
 


### PR DESCRIPTION
add option chain