### PR TITLE
Add `plugins` config to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,11 +129,11 @@ Add your preferred settings in your prettier config file.
 
 /** @type {import("@ianvs/prettier-plugin-sort-imports").PrettierConfig} */
 module.exports = {
-    printWidth: 80,
-    tabWidth: 4,
-    trailingComma: 'all',
+    // Standard prettier options
     singleQuote: true,
     semi: true,
+    // Since prettier 3.0, manually specifying plugins is required
+    plugins: ['@ianvs/prettier-plugin-sort-imports'],
     // This plugin's options
     importOrder: ['^@core/(.*)$', '', '^@server/(.*)$', '', '^@ui/(.*)$', '', '^[./]'],
     importOrderParserPlugins: ['typescript', 'jsx', 'decorators-legacy'],


### PR DESCRIPTION
Closes https://github.com/IanVS/prettier-plugin-sort-imports/issues/113

This adds a `plugins` config to the example in the `Usage` section of the readme.  It should work correctly in both Prettier 2 and 3, but is now required for 3.  