### PR TITLE
Fix #124 - type import specifier dupe

### DIFF
--- a/src/utils/__tests__/explode-type-and-value-specifiers.spec.ts
+++ b/src/utils/__tests__/explode-type-and-value-specifiers.spec.ts
@@ -82,6 +82,20 @@ test('it should return named type imports unchanged', () => {
     );
 });
 
+test('it should return inline named type imports unchanged', () => {
+    const code = `import { type NamedType1, type NamedType2 } from './source';`;
+    const importNodes = getImportNodes(code, { plugins: ['typescript'] });
+    const explodedNodes = explodeTypeAndValueSpecifiers(importNodes);
+    const formatted = getCodeFromAst({
+        nodesToOutput: explodedNodes,
+        originalCode: code,
+        directives: [],
+    });
+    expect(formatted).toEqual(
+        `import { type NamedType1, type NamedType2 } from './source';`,
+    );
+});
+
 test('it should separate named type and value imports', () => {
     const code = `import { named, type NamedType } from './source';`;
     const importNodes = getImportNodes(code, { plugins: ['typescript'] });

--- a/src/utils/explode-type-and-value-specifiers.ts
+++ b/src/utils/explode-type-and-value-specifiers.ts
@@ -37,7 +37,7 @@ export const explodeTypeAndValueSpecifiers: ExplodeTypeAndValueSpecifiers = (
         );
 
         // If we have a mix of type and value imports, we need to 'splode them into two import declarations
-        if (typeImports.length) {
+        if (typeImports.length && typeImports.length < node.specifiers.length) {
             const valueImports = node.specifiers.filter(
                 (i) =>
                     !(i.type === 'ImportSpecifier' && i.importKind === 'type'),


### PR DESCRIPTION
Proposed fix for the bug ticket I opened (Fixes https://github.com/IanVS/prettier-plugin-sort-imports/issues/124)

- Prevented type import exploding when no value imports are present
- Added test coverage to cover this edge-case