### PR TITLE
recommend using ^react$ for sorting react to the top.

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Here are some common ways to configure `importOrder`:
 Some styles call for putting the import of `react` at the top of your imports, which you could accomplish like this:
 
 ```json
-"importOrder": ["react", "<THIRD_PARTY_MODULES>", "^[.]"]
+"importOrder": ["^react$", "<THIRD_PARTY_MODULES>", "^[.]"]
 ```
 
 e.g.:


### PR DESCRIPTION
Hi there! 

I copy and pasted this from the readme and got confused when I found `react-query` and other `react-` imports also getting sorted to the top. I think it would be a simple change to recommend people use `^react$` instead of just `react` for sorting react to the top. 

Also, thanks so much for this plugin. It's incredible and exactly what I've been looking for!