### PR TITLE
fix: vue preprocessor may replace wrong code

### DIFF
--- a/tests/Vue/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/Vue/__snapshots__/ppsi.spec.ts.snap
@@ -1,5 +1,108 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`duplicates-between-blocks.vue - vue-verify > duplicates-between-blocks.vue 1`] = `
+<template>
+  <code>
+import z from 'z';
+import threeLevelRelativePath from "../../../threeLevelRelativePath";
+import sameLevelRelativePath from "./sameLevelRelativePath";
+import thirdParty from "third-party";
+import oneLevelRelativePath from "../oneLevelRelativePath";
+import otherthing from "@core/otherthing";
+import { defineComponent } from 'vue'
+function add(a,b) {
+  return a + b;
+}
+
+import z from 'z';
+import threeLevelRelativePath from "../../../threeLevelRelativePath";
+import sameLevelRelativePath from "./sameLevelRelativePath";
+import thirdParty from "third-party";
+import oneLevelRelativePath from "../oneLevelRelativePath";
+import otherthing from "@core/otherthing";
+import { defineComponent } from 'vue'
+function add(a,b) {
+  return a + b;
+}
+  </code>
+</template>
+
+<script>
+import z from 'z';
+import threeLevelRelativePath from "../../../threeLevelRelativePath";
+import sameLevelRelativePath from "./sameLevelRelativePath";
+import thirdParty from "third-party";
+import oneLevelRelativePath from "../oneLevelRelativePath";
+import otherthing from "@core/otherthing";
+import { defineComponent } from 'vue'
+function add(a,b) {
+  return a + b;
+}
+</script>
+
+<script setup>
+import z from 'z';
+import threeLevelRelativePath from "../../../threeLevelRelativePath";
+import sameLevelRelativePath from "./sameLevelRelativePath";
+import thirdParty from "third-party";
+import oneLevelRelativePath from "../oneLevelRelativePath";
+import otherthing from "@core/otherthing";
+import { defineComponent } from 'vue'
+function add(a,b) {
+  return a + b;
+}
+</script>~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<template>
+    <code>
+        import z from 'z'; import threeLevelRelativePath from
+        "../../../threeLevelRelativePath"; import sameLevelRelativePath from
+        "./sameLevelRelativePath"; import thirdParty from "third-party"; import
+        oneLevelRelativePath from "../oneLevelRelativePath"; import otherthing
+        from "@core/otherthing"; import { defineComponent } from 'vue' function
+        add(a,b) { return a + b; } import z from 'z'; import
+        threeLevelRelativePath from "../../../threeLevelRelativePath"; import
+        sameLevelRelativePath from "./sameLevelRelativePath"; import thirdParty
+        from "third-party"; import oneLevelRelativePath from
+        "../oneLevelRelativePath"; import otherthing from "@core/otherthing";
+        import { defineComponent } from 'vue' function add(a,b) { return a + b;
+        }
+    </code>
+</template>
+
+<script>
+import thirdParty from "third-party";
+import { defineComponent } from "vue";
+import z from "z";
+
+import otherthing from "@core/otherthing";
+
+import threeLevelRelativePath from "../../../threeLevelRelativePath";
+import oneLevelRelativePath from "../oneLevelRelativePath";
+import sameLevelRelativePath from "./sameLevelRelativePath";
+
+function add(a, b) {
+    return a + b;
+}
+</script>
+
+<script setup>
+import thirdParty from "third-party";
+import { defineComponent } from "vue";
+import z from "z";
+
+import otherthing from "@core/otherthing";
+
+import threeLevelRelativePath from "../../../threeLevelRelativePath";
+import oneLevelRelativePath from "../oneLevelRelativePath";
+import sameLevelRelativePath from "./sameLevelRelativePath";
+
+function add(a, b) {
+    return a + b;
+}
+</script>
+
+`;
+
 exports[`jsx-in-ts.vue - vue-verify > jsx-in-ts.vue 1`] = `
 <template>
     <router-view />

--- a/tests/Vue/duplicates-between-blocks.vue
+++ b/tests/Vue/duplicates-between-blocks.vue
@@ -1,0 +1,51 @@
+<template>
+  <code>
+import z from 'z';
+import threeLevelRelativePath from "../../../threeLevelRelativePath";
+import sameLevelRelativePath from "./sameLevelRelativePath";
+import thirdParty from "third-party";
+import oneLevelRelativePath from "../oneLevelRelativePath";
+import otherthing from "@core/otherthing";
+import { defineComponent } from 'vue'
+function add(a,b) {
+  return a + b;
+}
+
+import z from 'z';
+import threeLevelRelativePath from "../../../threeLevelRelativePath";
+import sameLevelRelativePath from "./sameLevelRelativePath";
+import thirdParty from "third-party";
+import oneLevelRelativePath from "../oneLevelRelativePath";
+import otherthing from "@core/otherthing";
+import { defineComponent } from 'vue'
+function add(a,b) {
+  return a + b;
+}
+  </code>
+</template>
+
+<script>
+import z from 'z';
+import threeLevelRelativePath from "../../../threeLevelRelativePath";
+import sameLevelRelativePath from "./sameLevelRelativePath";
+import thirdParty from "third-party";
+import oneLevelRelativePath from "../oneLevelRelativePath";
+import otherthing from "@core/otherthing";
+import { defineComponent } from 'vue'
+function add(a,b) {
+  return a + b;
+}
+</script>
+
+<script setup>
+import z from 'z';
+import threeLevelRelativePath from "../../../threeLevelRelativePath";
+import sameLevelRelativePath from "./sameLevelRelativePath";
+import thirdParty from "third-party";
+import oneLevelRelativePath from "../oneLevelRelativePath";
+import otherthing from "@core/otherthing";
+import { defineComponent } from 'vue'
+function add(a,b) {
+  return a + b;
+}
+</script>


### PR DESCRIPTION
Fix problem mentioned in #90 without changing dependency and shrimpwarp files.

See https://github.com/IanVS/prettier-plugin-sort-imports/pull/90#issuecomment-1758812882 for more details and explanation.