### PR TITLE
Fix: `node:test` not grouped with `<BUILTIN_MODULES>`

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,7 +25,7 @@ export const mergeableImportFlavors = [
 
 export const BUILTIN_MODULES_REGEX_STR = `(^(?:node:)?(?:${builtinModules.join(
     '|',
-)})$)|(^(?:node:test)$)`; // NOTE: 'test' is not included in `builtinModules` so explicitly check for "node:test"
+)})$)|(^node:test$)`; // NOTE: 'test' is not included in `builtinModules` so explicitly check for "node:test"
 
 export const BUILTIN_MODULES_SPECIAL_WORD = '<BUILTIN_MODULES>';
 /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,9 +23,9 @@ export const mergeableImportFlavors = [
     importFlavorType,
 ] as const;
 
-export const BUILTIN_MODULES_REGEX_STR = `^(?:node:)?(?:${builtinModules.join(
+export const BUILTIN_MODULES_REGEX_STR = `(^(?:node:)?(?:${builtinModules.join(
     '|',
-)})$`;
+)})$)|(^(?:node:test)$)`; // NOTE: 'test' is not included in `builtinModules` so explicitly check for "node:test"
 
 export const BUILTIN_MODULES_SPECIAL_WORD = '<BUILTIN_MODULES>';
 /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,7 +27,7 @@ export const mergeableImportFlavors = [
 // REF: https://github.com/nodejs/node/issues/42785
 export const BUILTIN_MODULES_REGEX_STR = `(^(?:node:)?(?:${builtinModules.join(
     '|',
-)})$)|(^node:test$)`; 
+)})$)|(^node:test$)`;
 
 export const BUILTIN_MODULES_SPECIAL_WORD = '<BUILTIN_MODULES>';
 /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,9 +23,11 @@ export const mergeableImportFlavors = [
     importFlavorType,
 ] as const;
 
+// NOTE: 'test' is not included in `builtinModules` so explicitly check for "node:test"
+// REF: https://github.com/nodejs/node/issues/42785
 export const BUILTIN_MODULES_REGEX_STR = `(^(?:node:)?(?:${builtinModules.join(
     '|',
-)})$)|(^node:test$)`; // NOTE: 'test' is not included in `builtinModules` so explicitly check for "node:test"
+)})$)|(^node:test$)`; 
 
 export const BUILTIN_MODULES_SPECIAL_WORD = '<BUILTIN_MODULES>';
 /**

--- a/tests/BuiltinModulesNodeTest/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/BuiltinModulesNodeTest/__snapshots__/ppsi.spec.ts.snap
@@ -1,0 +1,19 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`groups-node-test-with-builtin-modules.js - typescript-verify > groups-node-test-with-builtin-modules.js 1`] = `
+import nodeUtil from 'node:util';
+
+import nodeNodeTest from 'node:node:test';
+import nodeTest from 'node:test';
+import test from 'test'
+
+import fs from 'fs';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import fs from "fs";
+import nodeTest from "node:test";
+import nodeUtil from "node:util";
+
+import nodeNodeTest from "node:node:test";
+import test from "test";
+
+`;

--- a/tests/BuiltinModulesNodeTest/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/BuiltinModulesNodeTest/__snapshots__/ppsi.spec.ts.snap
@@ -3,9 +3,12 @@
 exports[`groups-node-test-with-builtin-modules.js - typescript-verify > groups-node-test-with-builtin-modules.js 1`] = `
 import nodeUtil from 'node:util';
 
+import nodeNodeTestTest from 'node:node:test:test';
 import nodeNodeTest from 'node:node:test';
+import nodeTestTest from 'node:test:test';
 import nodeTest from 'node:test';
 import test from 'test'
+import node from 'node';
 
 import fs from 'fs';
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -13,7 +16,10 @@ import fs from "fs";
 import nodeTest from "node:test";
 import nodeUtil from "node:util";
 
+import node from "node";
 import nodeNodeTest from "node:node:test";
+import nodeNodeTestTest from "node:node:test:test";
+import nodeTestTest from "node:test:test";
 import test from "test";
 
 `;

--- a/tests/BuiltinModulesNodeTest/groups-node-test-with-builtin-modules.js
+++ b/tests/BuiltinModulesNodeTest/groups-node-test-with-builtin-modules.js
@@ -1,0 +1,7 @@
+import nodeUtil from 'node:util';
+
+import nodeNodeTest from 'node:node:test';
+import nodeTest from 'node:test';
+import test from 'test'
+
+import fs from 'fs';

--- a/tests/BuiltinModulesNodeTest/groups-node-test-with-builtin-modules.js
+++ b/tests/BuiltinModulesNodeTest/groups-node-test-with-builtin-modules.js
@@ -1,7 +1,10 @@
 import nodeUtil from 'node:util';
 
+import nodeNodeTestTest from 'node:node:test:test';
 import nodeNodeTest from 'node:node:test';
+import nodeTestTest from 'node:test:test';
 import nodeTest from 'node:test';
 import test from 'test'
+import node from 'node';
 
 import fs from 'fs';

--- a/tests/BuiltinModulesNodeTest/ppsi.spec.ts
+++ b/tests/BuiltinModulesNodeTest/ppsi.spec.ts
@@ -1,0 +1,12 @@
+import {run_spec} from '../../test-setup/run_spec';
+
+run_spec(__dirname, ["typescript"], {
+    importOrder: [
+    "",
+    "<BUILTIN_MODULES>",
+    "",
+    "<THIRD_PARTY_MODULES>",
+    "",
+    "^[.]",
+    ],
+});


### PR DESCRIPTION
Following discussion in #142 , this adds an explicit check for `"node:test"` to `BUILTIN_MODULES_REGEX_STR` in order to properly group it with other builtin modules.

Test covers:
- `"node:test"` correctly gets grouped in with other builtin node modules
- `"node:test"` is correctly sorted among other builtin node modules
- `"*node:test"` is NOT grouped in with builtin modules
- `"node:test*"` is NOT grouped in with builtin modules
- `"node"` is NOT grouped in with builtin modules
- `"test"` is NOT grouped in with builtin modules

Fixes https://github.com/IanVS/prettier-plugin-sort-imports/issues/142