### PR TITLE
chore: upgrade babel parser version

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "dependencies": {
         "@babel/core": "^7.21.8",
         "@babel/generator": "^7.21.5",
-        "@babel/parser": "^7.21.8",
+        "@babel/parser": "^7.24.0",
         "@babel/traverse": "^7.23.2",
         "@babel/types": "^7.21.5",
         "semver": "^7.5.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -164,7 +164,7 @@
     "@babel/parser" "^7.22.15"
     "@babel/types" "^7.22.15"
 
-"@babel/traverse@^7.21.5", "@babel/traverse@^7.23.2":
+"@babel/traverse@^7.23.2":
   version "7.23.2"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.23.2.tgz#329c7a06735e144a506bdb2cad0268b7f46f4ad8"
   integrity sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==


### PR DESCRIPTION
hello, bumping up the babel parser version because I am using `prettier-plugin-sort-imports` in my codebase and using  latest `using` syntax resulted in a Prettier error

I poked around and found out it's because this syntax is is supported only since v7.22.0 of babel: see https://babeljs.io/blog/2023/05/26/7.22.0

thanks!