### PR TITLE
fix: augment Prettier `Options` types with internal `PluginConfig`

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Add your preferred settings in your prettier config file.
 ```ts
 // @ts-check
 
-/** @type {import("@ianvs/prettier-plugin-sort-imports").PrettierConfig} */
+/** @type {import("prettier").Config} */
 module.exports = {
     // Standard prettier options
     singleQuote: true,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -72,3 +72,7 @@ export interface PluginConfig {
 }
 
 export type PrettierConfig = PluginConfig & Config;
+
+declare module 'prettier' {
+    interface Options extends PluginConfig {}
+}


### PR DESCRIPTION
- Add TypeScript module augmentation for the `prettier` module in `types/index.d.ts` to add the `PluginConfig` interface to the `Options` interface to support proper typing of plugin options in IDEs and during type-checking
- Closes #169
- Compiles and passes tests