### PR TITLE
Fix vue 2.7 support

### DIFF
--- a/src/preprocessors/vue.ts
+++ b/src/preprocessors/vue.ts
@@ -36,8 +36,8 @@ export function vuePreprocessor(code: string, options: PrettierOptions) {
             // [start, end)
 
             // @ts-expect-error Some vue versions have a `block.loc`, others have start and end directly on the block
-            let {start, end} = block;
-            if ("loc" in block) {
+            let { start, end } = block;
+            if ('loc' in block) {
                 start = block.loc.start.offset;
                 end = block.loc.end.offset;
             }

--- a/src/preprocessors/vue.ts
+++ b/src/preprocessors/vue.ts
@@ -34,10 +34,16 @@ export function vuePreprocessor(code: string, options: PrettierOptions) {
             // https://github.com/vuejs/core/blob/b8fc18c0b23be9a77b05dc41ed452a87a0becf82/packages/compiler-core/src/ast.ts#L74-L80
             // The node's range. The `start` is inclusive and `end` is exclusive.
             // [start, end)
-            const { start, end } = block.loc;
+
+            // @ts-expect-error Some vue versions have a `block.loc`, others have start and end directly on the block
+            let {start, end} = block;
+            if ("loc" in block) {
+                start = block.loc.start.offset;
+                end = block.loc.end.offset;
+            }
             const preprocessedBlockCode = sortScript(block, options);
-            result += code.slice(offset, start.offset) + preprocessedBlockCode;
-            offset = end.offset;
+            result += code.slice(offset, start) + preprocessedBlockCode;
+            offset = end;
         }
 
         // 4. Append the rest.

--- a/src/preprocessors/vue.ts
+++ b/src/preprocessors/vue.ts
@@ -54,8 +54,8 @@ export function vuePreprocessor(code: string, options: PrettierOptions) {
             console.warn(
                 '[@ianvs/prettier-plugin-sort-imports]: Could not process .vue file.  Please be sure that "@vue/compiler-sfc" is installed in your project.',
             );
-            throw err;
         }
+        throw err;
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/IanVS/prettier-plugin-sort-imports/issues/162

Older versions (not sure which ones exactly) of vue/compiler-sfc do not include a `loc` property on each block, but rather give the offsets directly on the block itself.  This accounts for those differences, and causes the reproduction provided in the issue to succeed.