### PR TITLE
Throw an error when no matching sortOrder group

### DIFF
--- a/src/utils/get-sorted-nodes-by-import-order.ts
+++ b/src/utils/get-sorted-nodes-by-import-order.ts
@@ -56,11 +56,16 @@ export const getSortedNodesByImportOrder: GetSortedNodesByImportOrder = (
 
     // Assign import nodes into import order groups
     for (const node of originalNodes) {
-        const matchedGroup = getImportNodesMatchedGroup(
+        const matchedGroupName = getImportNodesMatchedGroup(
             node,
             sanitizedImportOrder,
         );
-        importOrderGroups[matchedGroup].push(node);
+        const matchedGroup = importOrderGroups[matchedGroupName];
+        if (matchedGroup) {
+            matchedGroup.push(node);
+        } else {
+            throw(new Error(`Could not find a matching group in importOrder for: "${node.source.value}" on line ${node.source.loc?.start.line}`));
+        }
     }
 
     for (const group of importOrder) {

--- a/src/utils/get-sorted-nodes-by-import-order.ts
+++ b/src/utils/get-sorted-nodes-by-import-order.ts
@@ -64,7 +64,9 @@ export const getSortedNodesByImportOrder: GetSortedNodesByImportOrder = (
         if (matchedGroup) {
             matchedGroup.push(node);
         } else {
-            throw(new Error(`Could not find a matching group in importOrder for: "${node.source.value}" on line ${node.source.loc?.start.line}.${node.importKind === 'type' ? ' Did you forget to include "<TYPES>"?' : ''}`));
+            throw new Error(
+                `Could not find a matching group in importOrder for: "${node.source.value}" on line ${node.source.loc?.start.line}.${node.importKind === 'type' ? ' Did you forget to include "<TYPES>"?' : ''}`,
+            );
         }
     }
 

--- a/src/utils/get-sorted-nodes-by-import-order.ts
+++ b/src/utils/get-sorted-nodes-by-import-order.ts
@@ -64,7 +64,7 @@ export const getSortedNodesByImportOrder: GetSortedNodesByImportOrder = (
         if (matchedGroup) {
             matchedGroup.push(node);
         } else {
-            throw(new Error(`Could not find a matching group in importOrder for: "${node.source.value}" on line ${node.source.loc?.start.line}`));
+            throw(new Error(`Could not find a matching group in importOrder for: "${node.source.value}" on line ${node.source.loc?.start.line}.${node.importKind === 'type' ? ' Did you forget to include "<TYPES>"?' : ''}`));
         }
     }
 

--- a/test-setup/run_spec.ts
+++ b/test-setup/run_spec.ts
@@ -64,7 +64,12 @@ export async function run_spec(dirname, parsers, options) {
     }
 }
 
-export async function expectError(dirname: string, parser: string, expectedError: string | Error | RegExp, options) {
+export async function expectError(
+    dirname: string,
+    parser: string,
+    expectedError: string | Error | RegExp,
+    options,
+) {
     options = Object.assign(
         {
             plugins: options.plugins ?? [plugin],
@@ -89,11 +94,11 @@ export async function expectError(dirname: string, parser: string, expectedError
             const source = read(path).replace(/\r\n/g, '\n');
 
             const mergedOptions = Object.assign({}, options, {
-                parser
+                parser,
             });
             test(`${filename} - verify-error`, async () => {
-                expect(
-                   () => prettyprint(source, path, mergedOptions)
+                expect(() =>
+                    prettyprint(source, path, mergedOptions),
                 ).rejects.toThrowError(expectedError);
             });
         }

--- a/tests/ImportOrderMissing/importOrderMissing.ts
+++ b/tests/ImportOrderMissing/importOrderMissing.ts
@@ -1,0 +1,4 @@
+import Foo from "./bar";
+import type {Justify} from "#utils"
+import type {React} from "React";
+import type {Internal} from "./types.ts";

--- a/tests/ImportOrderMissing/ppsi.spec.ts
+++ b/tests/ImportOrderMissing/ppsi.spec.ts
@@ -3,7 +3,7 @@ import {expectError} from '../../test-setup/run_spec';
 expectError(
     __dirname,
     "typescript",
-    "Could not find a matching group in importOrder for: \"React\" on line 3",
+    /Could not find a matching group in importOrder for: \"React\" on line 3. Did you forget to include \"<TYPES>\"\?$/,
     {
         importOrder: ['^[./]', '<TYPES>^#utils$', '<TYPES>[.]'],
         importOrderParserPlugins: ['typescript'],

--- a/tests/ImportOrderMissing/ppsi.spec.ts
+++ b/tests/ImportOrderMissing/ppsi.spec.ts
@@ -1,0 +1,11 @@
+import {expectError} from '../../test-setup/run_spec';
+
+expectError(
+    __dirname,
+    "typescript",
+    "Could not find a matching group in importOrder for: \"React\" on line 3",
+    {
+        importOrder: ['^[./]', '<TYPES>^#utils$', '<TYPES>[.]'],
+        importOrderParserPlugins: ['typescript'],
+    }
+);


### PR DESCRIPTION
Closes #190 

This adds a more understandable error message when we encounter an import that does not fit into any group within `sortOrder`.  I think the only time that should happen is when the user adds groups with `<TYPES>^.....` but no fallback `<TYPES>` bucket.  We could try to shove one in somewhere automatically like we do with `<THIRD_PARTY_MODULES>`, but that could be pretty confusing and I don't know where it should go in that case.  This also includes a hint about how to fix the error.