### PR TITLE
fix: catch babel parse errors

### DIFF
--- a/src/preprocessors/preprocessor.ts
+++ b/src/preprocessors/preprocessor.ts
@@ -26,7 +26,9 @@ export function preprocessor(code: string, options: PrettierOptions): string {
     try {
         ast = babelParser(code, parserOptions);
     } catch (_) {
-        console.error(' [error] [prettier-plugin-sort-imports]: import sorting aborted due to babel parsing error.');
+        console.error(
+            ' [error] [prettier-plugin-sort-imports]: import sorting aborted due to babel parsing error.',
+        );
         return code;
     }
 

--- a/src/preprocessors/preprocessor.ts
+++ b/src/preprocessors/preprocessor.ts
@@ -22,7 +22,13 @@ export function preprocessor(code: string, options: PrettierOptions): string {
         parserOptions.allowReturnOutsideFunction = true;
     }
 
-    const ast = babelParser(code, parserOptions);
+    let ast;
+    try {
+        ast = babelParser(code, parserOptions);
+    } catch (_) {
+        console.error(' [error] [prettier-plugin-sort-imports]: import sorting aborted due to babel parsing error.');
+        return code;
+    }
 
     const directives = ast.program.directives;
     const interpreter = ast.program.interpreter;

--- a/src/preprocessors/preprocessor.ts
+++ b/src/preprocessors/preprocessor.ts
@@ -22,7 +22,7 @@ export function preprocessor(code: string, options: PrettierOptions): string {
         parserOptions.allowReturnOutsideFunction = true;
     }
 
-    let ast;
+    let ast: ReturnType<typeof babelParser>;
     try {
         ast = babelParser(code, parserOptions);
     } catch (_) {


### PR DESCRIPTION
This change updates the plugin to catch babel parsing errors, so that we can give prettier a chance to throw.  We're still writing an error to console, so that in the event that prettier doesn't end up throwing, we're still indicating that the import sorting failed.

![screenshot of new behavior](https://github.com/user-attachments/assets/8ce5daaf-e496-4260-85d0-6753b137f9eb)

Closes #197 