### PR TITLE
Update peerDeps to allow prettier v4.

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     },
     "peerDependencies": {
         "@vue/compiler-sfc": "2.7.x || 3.x",
-        "prettier": "2 || 3"
+        "prettier": "2 || 3 || 4"
     },
     "peerDependenciesMeta": {
         "@vue/compiler-sfc": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     },
     "peerDependencies": {
         "@vue/compiler-sfc": "2.7.x || 3.x",
-        "prettier": "2 || 3 || 4"
+        "prettier": "2 || 3 || ^4.0.0-0"
     },
     "peerDependenciesMeta": {
         "@vue/compiler-sfc": {


### PR DESCRIPTION
I've been using the v4 alphas of prettier for a *very long time*, and they have always worked just fine with this plugin.