### PR TITLE
Short-circuit before parsing

### DIFF
--- a/src/preprocessors/preprocessor.ts
+++ b/src/preprocessors/preprocessor.ts
@@ -17,6 +17,11 @@ export function preprocessor(code: string, options: PrettierOptions): string {
         plugins,
     };
 
+    // short-circuit if importOrder is an empty array (can be used to disable plugin)
+    if (!remainingOptions.importOrder.length) {
+        return code;
+    }
+
     // Astro component scripts allow returning a response
     if (options.parentParser === 'astro') {
         parserOptions.allowReturnOutsideFunction = true;
@@ -50,11 +55,6 @@ export function preprocessor(code: string, options: PrettierOptions): string {
 
     // short-circuit if there are no import declarations
     if (allOriginalImportNodes.length === 0) {
-        return code;
-    }
-
-    // short-circuit if importOrder is an empty array (can be used to disable plugin)
-    if (!remainingOptions.importOrder.length) {
         return code;
     }
 


### PR DESCRIPTION
In attempting to troubleshoot https://github.com/IanVS/prettier-plugin-sort-imports/issues/219, I realized that disabling the plugin using overrides and `importOrder: []` does not prevent parsing errors.  Moving this short-circuit check up before we attempt to parse will not only solve that problem but also improve performance a little by avoiding parsing files that we're just going to short-circuit anyway.