### PR TITLE
Be more tolerant of babel parse errors

### DIFF
--- a/tests/InvalidSyntax/__snapshots__/ppsi.spec.ts.snap
+++ b/tests/InvalidSyntax/__snapshots__/ppsi.spec.ts.snap
@@ -1,0 +1,61 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`invalidSet.ts - typescript-verify > invalidSet.ts 1`] = `
+import b from './b';
+import a from './a';
+
+const c = {set name(){}}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import a from "./a";
+import b from "./b";
+
+const c = { set name() {} };
+
+`;
+
+exports[`redeclare.js - typescript-verify > redeclare.js 1`] = `
+import b from './b';
+import a from './a';
+
+// Here's an invalid example of redeclaring a variable
+let   name    =     "error"   ;
+let name = "error";
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import a from "./a";
+import b from "./b";
+
+// Here's an invalid example of redeclaring a variable
+let name = "error";
+let name = "error";
+
+`;
+
+exports[`returnOutsideFunction.ts - typescript-verify > returnOutsideFunction.ts 1`] = `
+import b from './b';
+import a from './a';
+
+// Can't return outside of a function
+return 123;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import a from "./a";
+import b from "./b";
+
+// Can't return outside of a function
+return 123;
+
+`;
+
+exports[`superOutsideMethod.ts - typescript-verify > superOutsideMethod.ts 1`] = `
+import b from './b';
+import a from './a';
+
+function F() { super(); }
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import a from "./a";
+import b from "./b";
+
+function F() {
+    super();
+}
+
+`;

--- a/tests/InvalidSyntax/invalidSet.ts
+++ b/tests/InvalidSyntax/invalidSet.ts
@@ -1,0 +1,4 @@
+import b from './b';
+import a from './a';
+
+const c = {set name(){}}

--- a/tests/InvalidSyntax/ppsi.spec.ts
+++ b/tests/InvalidSyntax/ppsi.spec.ts
@@ -1,0 +1,6 @@
+import { run_spec } from '../../test-setup/run_spec';
+
+run_spec(__dirname, ['typescript'], {
+    importOrder: ['^@core/(.*)$', '^@server/(.*)', '^@ui/(.*)$', '^[./]'],
+    importOrderParserPlugins : ['typescript'],
+});

--- a/tests/InvalidSyntax/redeclare.js
+++ b/tests/InvalidSyntax/redeclare.js
@@ -1,0 +1,6 @@
+import b from './b';
+import a from './a';
+
+// Here's an invalid example of redeclaring a variable
+let   name    =     "error"   ;
+let name = "error";

--- a/tests/InvalidSyntax/returnOutsideFunction.ts
+++ b/tests/InvalidSyntax/returnOutsideFunction.ts
@@ -1,0 +1,5 @@
+import b from './b';
+import a from './a';
+
+// Can't return outside of a function
+return 123;

--- a/tests/InvalidSyntax/superOutsideMethod.ts
+++ b/tests/InvalidSyntax/superOutsideMethod.ts
@@ -1,0 +1,4 @@
+import b from './b';
+import a from './a';
+
+function F() { super(); }


### PR DESCRIPTION
Closes #219
Closes #222 

This change makes our babel parsing and node traversal more tolerant of errors, matching the settings and behavior of Prettier itself.  Now, rather than this plugin causing an error and failing to format the file, it will continue to attempt to sort imports.  It may still fail on invalid code, but in those cases prettier itself would as well, so we shouldn't end up in a case where prettier runs but imports aren't sorted, or where prettier would have run as long as this plugin wasn't being used.

I chose not to emit a warning when invalid syntax is encountered, again matching the behavior or prettier.  I don't think it's the responsibility of a import sorting plugin to alert the user to invalid syntax, since it may be intentional and handled later-on in their build pipeline (for instance, Astro files allow returning from the top-level).  