### PR TITLE
Do not warn for markdown code blocks

### DIFF
--- a/src/preprocessors/preprocessor.ts
+++ b/src/preprocessors/preprocessor.ts
@@ -43,10 +43,16 @@ export function preprocessor(
     try {
         ast = babelParser(parseableCode ?? originalCode, parserOptions);
     } catch (err) {
-        console.error(
-            ' [error] [prettier-plugin-sort-imports]: import sorting aborted due to parsing error:\n%s',
-            err,
-        );
+        // Don't throw warning messages if this is a codeblock in markdown.  (Prettier doesn't either)
+        if (
+            options.parentParser !== 'markdown' &&
+            options.parentParser !== 'mdx'
+        ) {
+            console.error(
+                ' [error] [prettier-plugin-sort-imports]: import sorting aborted due to parsing error:\n%s',
+                err,
+            );
+        }
         return originalCode;
     }
 


### PR DESCRIPTION
Closes #222 

This will stop throwing error messages for un-parsable code blocks in markdown (and mdx) files.  

This isn't ideal, but it matches the behavior of Prettier itself. See https://github.com/IanVS/prettier-plugin-sort-imports/issues/222#issuecomment-3167848337 for some discussion.