### PR TITLE
fix: conditionally register ember and oxc parsers when dependencies available

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,15 @@ const getEmberPlugin = () => {
     }
 };
 
+const isEmberPluginAvailable = () => {
+    try {
+        getEmberPlugin();
+        return true;
+    } catch {
+        return false;
+    }
+};
+
 const getOxcPlugin = () => {
     try {
         const oxcPlugin = require('@prettier/plugin-oxc');
@@ -79,6 +88,15 @@ const getOxcPlugin = () => {
     }
 };
 
+const isOxcPluginAvailable = () => {
+    try {
+        getOxcPlugin();
+        return true;
+    } catch {
+        return false;
+    }
+};
+
 export const parsers = {
     babel: {
         ...babelParsers.babel,
@@ -88,34 +106,26 @@ export const parsers = {
         ...babelParsers['babel-ts'],
         preprocess: defaultPreprocessor,
     },
-    get 'ember-template-tag'() {
-        const emberPlugin = getEmberPlugin();
-
-        return {
-            ...emberPlugin.parsers['ember-template-tag'],
+    ...(isEmberPluginAvailable() && {
+        'ember-template-tag': {
+            ...getEmberPlugin().parsers['ember-template-tag'],
             preprocess: emberPreprocessor,
-        };
-    },
+        },
+    }),
     flow: {
         ...flowParsers.flow,
         preprocess: defaultPreprocessor,
     },
-    get oxc() {
-        const oxcPlugin = getOxcPlugin();
-
-        return {
-            ...oxcPlugin.parsers.oxc,
+    ...(isOxcPluginAvailable() && {
+        oxc: {
+            ...getOxcPlugin().parsers.oxc,
             preprocess: defaultPreprocessor,
-        };
-    },
-    get 'oxc-ts'() {
-        const oxcPlugin = getOxcPlugin();
-
-        return {
-            ...oxcPlugin.parsers['oxc-ts'],
+        },
+        'oxc-ts': {
+            ...getOxcPlugin().parsers['oxc-ts'],
             preprocess: defaultPreprocessor,
-        };
-    },
+        },
+    }),
     typescript: {
         ...typescriptParsers.typescript,
         preprocess: defaultPreprocessor,
@@ -127,9 +137,7 @@ export const parsers = {
 };
 
 export const printers = {
-    get 'estree-oxc'() {
-        const oxcPlugin = getOxcPlugin();
-
-        return oxcPlugin.printers['estree-oxc'];
-    },
+    ...(isOxcPluginAvailable() && {
+        'estree-oxc': getOxcPlugin().printers['estree-oxc'],
+    }),
 };


### PR DESCRIPTION
Prevents errors when prettier-plugin-ember-template-tag or @prettier/plugin-oxc are not installed. The previous getter-based lazy loading caused errors during parser enumeration by other plugins (like prettier-plugin-toml), breaking compatibility. Now parsers are only registered when dependencies exist.

resolves #233

## Testing

I tested by removing the spread operators and confirmed relevant tests fail.
I also tested with my [repro](https://github.com/jahands/prettier-sort-imports-plugin-repro#) posted in #223 and confirmed it no longer errors