### PR TITLE
Fix range formatting import boundary whitespace and skip unrelated import sorting

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -37,7 +37,7 @@ export const BUILTIN_MODULES_SPECIAL_WORD = '<BUILTIN_MODULES>';
 export const THIRD_PARTY_MODULES_SPECIAL_WORD = '<THIRD_PARTY_MODULES>';
 export const TYPES_SPECIAL_WORD = '<TYPES>';
 
-const PRETTIER_PLUGIN_SORT_IMPORTS_NEW_LINE =
+export const PRETTIER_PLUGIN_SORT_IMPORTS_NEW_LINE =
     'PRETTIER_PLUGIN_SORT_IMPORTS_NEW_LINE';
 
 /** Use this to force a newline at top-level scope (good for newlines generated between import blocks) */
@@ -52,9 +52,6 @@ export const forceANewlineUsingACommentStatement = () => ({
     end: -1,
     loc: { start: { line: -1, column: -1 }, end: { line: -1, column: -1 } },
 });
-
-export const injectNewlinesRegex =
-    /("PRETTIER_PLUGIN_SORT_IMPORTS_NEW_LINE";|\/\/PRETTIER_PLUGIN_SORT_IMPORTS_NEWLINE_COMMENT)/gi;
 
 // This default is set by prettier itself by including it in our config in index.ts
 export const DEFAULT_IMPORT_ORDER = [

--- a/src/preprocessors/default.ts
+++ b/src/preprocessors/default.ts
@@ -1,7 +1,12 @@
 import { PrettierOptions } from '../types';
+import { getPartialFormatRange } from './format-range';
 import { preprocessor } from './preprocessor';
 
 export function defaultPreprocessor(code: string, options: PrettierOptions) {
     if (options.filepath?.endsWith('.vue')) return code;
-    return preprocessor(code, { options });
+
+    return preprocessor(code, {
+        options,
+        formatRange: getPartialFormatRange(code, options),
+    });
 }

--- a/src/preprocessors/ember.ts
+++ b/src/preprocessors/ember.ts
@@ -3,9 +3,11 @@ import {
     extractTemplates,
     preprocessTemplateRange,
 } from '../utils/glimmer-content-tag';
+import { getPartialFormatRange } from './format-range';
 import { preprocessor } from './preprocessor';
 
 export function emberPreprocessor(code: string, options: PrettierOptions) {
+    const formatRange = getPartialFormatRange(code, options);
     let parseableCode = code;
     const templates = extractTemplates(code);
 
@@ -13,7 +15,7 @@ export function emberPreprocessor(code: string, options: PrettierOptions) {
         parseableCode = preprocessTemplateRange(template, parseableCode);
     }
 
-    const sorted = preprocessor(code, { parseableCode, options });
+    const sorted = preprocessor(code, { parseableCode, options, formatRange });
 
     return sorted;
 }

--- a/src/preprocessors/format-range.ts
+++ b/src/preprocessors/format-range.ts
@@ -1,0 +1,57 @@
+import { PrettierOptions } from '../types';
+
+export interface FormatRange {
+    start: number;
+    end: number;
+}
+
+export function getPartialFormatRange(
+    code: string,
+    options: PrettierOptions,
+): FormatRange | null {
+    const start = clampRangeIndex(options.rangeStart, code.length, 0);
+    const end = clampRangeIndex(options.rangeEnd, code.length, code.length);
+
+    if (start <= 0 && end >= code.length) {
+        return null;
+    }
+
+    return {
+        start,
+        end,
+    };
+}
+
+export function rangesOverlap(
+    firstRange: FormatRange,
+    secondRange: FormatRange,
+) {
+    return (
+        firstRange.end > secondRange.start && secondRange.end > firstRange.start
+    );
+}
+
+export function toLocalFormatRange(
+    fileRange: FormatRange,
+    containerRange: FormatRange,
+): FormatRange | null {
+    const start = Math.max(fileRange.start, containerRange.start);
+    const end = Math.min(fileRange.end, containerRange.end);
+
+    if (end <= start) {
+        return null;
+    }
+
+    return {
+        start: start - containerRange.start,
+        end: end - containerRange.start,
+    };
+}
+
+function clampRangeIndex(value: number, codeLength: number, fallback: number) {
+    if (!Number.isFinite(value)) {
+        return fallback;
+    }
+
+    return Math.max(0, Math.min(value, codeLength));
+}

--- a/src/preprocessors/preprocessor.ts
+++ b/src/preprocessors/preprocessor.ts
@@ -2,9 +2,11 @@ import { parse as babelParser, ParserOptions } from '@babel/parser';
 
 import { PrettierOptions } from '../types';
 import { extractASTNodes } from '../utils/extract-ast-nodes';
+import { getAllCommentsFromNodes } from '../utils/get-all-comments-from-nodes';
 import { getCodeFromAst } from '../utils/get-code-from-ast';
 import { getSortedNodes } from '../utils/get-sorted-nodes';
 import { examineAndNormalizePluginOptions } from '../utils/normalize-plugin-options';
+import { rangesOverlap, type FormatRange } from './format-range';
 
 /**
  *
@@ -18,7 +20,12 @@ export function preprocessor(
     {
         options,
         parseableCode,
-    }: { options: PrettierOptions; parseableCode?: string },
+        formatRange,
+    }: {
+        options: PrettierOptions;
+        parseableCode?: string;
+        formatRange?: FormatRange | null;
+    },
 ): string {
     const { plugins, ...remainingOptions } =
         examineAndNormalizePluginOptions(options);
@@ -66,6 +73,10 @@ export function preprocessor(
         return originalCode;
     }
 
+    if (!shouldSortImports(allOriginalImportNodes, formatRange)) {
+        return originalCode;
+    }
+
     const nodesToOutput = getSortedNodes(
         allOriginalImportNodes,
         remainingOptions,
@@ -79,3 +90,48 @@ export function preprocessor(
         interpreter,
     });
 }
+
+const shouldSortImports = (
+    allOriginalImportNodes: ReturnType<
+        typeof extractASTNodes
+    >['importDeclarations'],
+    formatRange?: FormatRange | null,
+) => {
+    if (!formatRange) {
+        return true;
+    }
+
+    const importBlockRange = getNodeRange([
+        ...allOriginalImportNodes,
+        ...getAllCommentsFromNodes(allOriginalImportNodes),
+    ]);
+
+    return importBlockRange
+        ? rangesOverlap(formatRange, importBlockRange)
+        : true;
+};
+
+const getNodeRange = (
+    nodes: Array<{ start?: number | null; end?: number | null }>,
+) => {
+    let start: number | null = null;
+    let end: number | null = null;
+
+    for (const node of nodes) {
+        if (typeof node.start !== 'number' || typeof node.end !== 'number') {
+            continue;
+        }
+
+        start = start === null ? node.start : Math.min(start, node.start);
+        end = end === null ? node.end : Math.max(end, node.end);
+    }
+
+    if (start === null || end === null) {
+        return null;
+    }
+
+    return {
+        start,
+        end,
+    };
+};

--- a/src/preprocessors/vue.ts
+++ b/src/preprocessors/vue.ts
@@ -3,6 +3,11 @@ import type { SFCDescriptor } from '@vue/compiler-sfc';
 import { ImportOrderParserPlugin } from '../../types';
 import { PrettierOptions } from '../types';
 import { hasPlugin } from '../utils/get-experimental-parser-plugins';
+import {
+    getPartialFormatRange,
+    toLocalFormatRange,
+    type FormatRange,
+} from './format-range';
 import { preprocessor } from './preprocessor';
 
 // Non-exhaustive, describes just the properties needed for type guarding
@@ -12,6 +17,7 @@ type VueBlock = BaseBlock | LocBlock;
 
 export function vuePreprocessor(code: string, options: PrettierOptions) {
     try {
+        const fileFormatRange = getVueFormatRange(code, options);
         const { parse } = require('@vue/compiler-sfc');
         const version =
             require('@vue/compiler-sfc/package.json').version?.split('.')[0];
@@ -50,7 +56,16 @@ export function vuePreprocessor(code: string, options: PrettierOptions) {
             const end = isLocBlock(block)
                 ? block.loc.end.offset
                 : (block as BaseBlock).end.offset;
-            const preprocessedBlockCode = sortScript(block, options);
+            const preprocessedBlockCode = getPreprocessedBlockCode(
+                block,
+                options,
+                {
+                    start,
+                    end,
+                    fileFormatRange,
+                    originalCode: code,
+                },
+            );
             result += code.slice(offset, start) + preprocessedBlockCode;
             offset = end;
         }
@@ -66,6 +81,66 @@ export function vuePreprocessor(code: string, options: PrettierOptions) {
         }
         throw err;
     }
+}
+
+function getVueFormatRange(code: string, options: PrettierOptions) {
+    const currentFormatRange = getPartialFormatRange(code, options);
+
+    if (currentFormatRange) {
+        options.ppsiVueOriginalRangeStart = currentFormatRange.start;
+        options.ppsiVueOriginalRangeEnd = currentFormatRange.end;
+
+        return currentFormatRange;
+    }
+
+    if (
+        typeof options.ppsiVueOriginalRangeStart !== 'number' ||
+        typeof options.ppsiVueOriginalRangeEnd !== 'number'
+    ) {
+        return null;
+    }
+
+    return {
+        start: Math.max(
+            0,
+            Math.min(options.ppsiVueOriginalRangeStart, code.length),
+        ),
+        end: Math.max(
+            0,
+            Math.min(options.ppsiVueOriginalRangeEnd, code.length),
+        ),
+    };
+}
+
+function getPreprocessedBlockCode(
+    block: { content: string; lang?: string },
+    options: PrettierOptions,
+    {
+        start,
+        end,
+        fileFormatRange,
+        originalCode,
+    }: {
+        start: number;
+        end: number;
+        fileFormatRange: FormatRange | null;
+        originalCode: string;
+    },
+) {
+    if (!fileFormatRange) {
+        return sortScript(block, options);
+    }
+
+    const blockFormatRange = toLocalFormatRange(fileFormatRange, {
+        start,
+        end,
+    });
+
+    if (!blockFormatRange) {
+        return originalCode.slice(start, end);
+    }
+
+    return sortScript(block, options, blockFormatRange);
 }
 
 /**
@@ -92,6 +167,7 @@ function isTS(lang?: string) {
 function sortScript(
     { content, lang }: { content: string; lang?: string },
     options: PrettierOptions,
+    formatRange?: FormatRange | null,
 ) {
     const { importOrderParserPlugins = [] } = options;
     let pluginClone = [...importOrderParserPlugins];
@@ -117,5 +193,8 @@ function sortScript(
         importOrderParserPlugins: newPlugins,
     };
 
-    return `\n${preprocessor(content, { options: adjustedOptions })}\n`;
+    return `\n${preprocessor(content, {
+        options: adjustedOptions,
+        formatRange,
+    })}\n`;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,10 @@ import { chunkTypeOther, chunkTypeUnsortable } from './constants';
 import { examineAndNormalizePluginOptions } from './utils/normalize-plugin-options';
 
 export interface PrettierOptions
-    extends Required<PluginConfig>, RequiredOptions {}
+    extends Required<PluginConfig>, RequiredOptions {
+    ppsiVueOriginalRangeStart?: number;
+    ppsiVueOriginalRangeEnd?: number;
+}
 
 /** Subset of options that need to be normalized, or affect normalization */
 export type NormalizableOptions = Pick<

--- a/src/utils/__tests__/get-code-from-ast.spec.ts
+++ b/src/utils/__tests__/get-code-from-ast.spec.ts
@@ -186,6 +186,27 @@ const value = 1;
 `);
 });
 
+// Verifies original extra spacing is preserved even when the next top-level item is a comment.
+test('preserves extra blank lines before the next top-level comment', () => {
+    const code = `import z from 'z';
+import a from 'a';
+
+
+
+// next block
+const value = 1;
+`;
+
+    expect(sortCode({ code })).toBe(`import a from 'a';
+import z from 'z';
+
+
+
+// next block
+const value = 1;
+`);
+});
+
 // Verifies boundary cleanup preserves both the original extra gap and the indentation on the next real line.
 test('preserves indentation on the first non-empty line after imports', () => {
     const code = `import z from 'z';

--- a/src/utils/__tests__/get-code-from-ast.spec.ts
+++ b/src/utils/__tests__/get-code-from-ast.spec.ts
@@ -1,3 +1,4 @@
+import { parse as babelParser, type ParserOptions } from '@babel/parser';
 import { format } from 'prettier';
 import { expect, test } from 'vitest';
 
@@ -9,7 +10,73 @@ import { testingOnly } from '../normalize-plugin-options';
 
 const defaultImportOrder =
     testingOnly.normalizeImportOrderOption(DEFAULT_IMPORT_ORDER);
+const separatedImportOrder = testingOnly.normalizeImportOrderOption([
+    '<BUILTIN_MODULES>',
+    '',
+    '<THIRD_PARTY_MODULES>',
+    '',
+    '^[.]',
+]);
 
+const createSortOptions = (importOrder = defaultImportOrder) => ({
+    importOrder,
+    importOrderCombineTypeAndValueImports: true,
+    importOrderCaseSensitive: false,
+    importOrderSafeSideEffects: [],
+    hasAnyCustomGroupSeparatorsInImportOrder: importOrder.some(
+        (group) => group.trim() === '',
+    ),
+    provideGapAfterTopOfFileComments: importOrder[0]?.trim() === '',
+});
+
+const sortCode = ({
+    code,
+    importOrder = defaultImportOrder,
+    parserOptions = {},
+}: {
+    code: string;
+    importOrder?: string[];
+    parserOptions?: ParserOptions;
+}) => {
+    const ast = babelParser(code, {
+        ...parserOptions,
+        attachComment: true,
+        sourceType: 'module',
+    });
+    const importNodes = getImportNodes(code, {
+        ...parserOptions,
+        attachComment: true,
+    });
+    const sortedNodes = getSortedNodes(
+        importNodes,
+        createSortOptions(importOrder),
+    );
+
+    return getCodeFromAst({
+        nodesToOutput: sortedNodes,
+        allOriginalImportNodes: importNodes,
+        originalCode: code,
+        directives: ast.program.directives,
+        interpreter: ast.program.interpreter,
+    });
+};
+
+const sortAndFormatCode = async ({
+    code,
+    importOrder = defaultImportOrder,
+    parserOptions = {},
+    prettierParser,
+}: {
+    code: string;
+    importOrder?: string[];
+    parserOptions?: ParserOptions;
+    prettierParser: 'babel' | 'typescript';
+}) =>
+    format(sortCode({ code, importOrder, parserOptions }), {
+        parser: prettierParser,
+    });
+
+// Verifies the baseline sort path still emits imports in normalized order.
 test('sorts imports correctly', async () => {
     const code = `import z from 'z';
 import c from 'c';
@@ -18,31 +85,18 @@ import t from 't';
 import k from 'k';
 import a from 'a';
 `;
-    const importNodes = getImportNodes(code);
-    const sortedNodes = getSortedNodes(importNodes, {
-        importOrder: defaultImportOrder,
-        importOrderCombineTypeAndValueImports: true,
-        importOrderCaseSensitive: false,
-        importOrderSafeSideEffects: [],
-        hasAnyCustomGroupSeparatorsInImportOrder: false,
-        provideGapAfterTopOfFileComments: false,
-    });
-    const formatted = getCodeFromAst({
-        nodesToOutput: sortedNodes,
-        originalCode: code,
-        directives: [],
-    });
-    expect(await format(formatted, { parser: 'babel' })).toEqual(
-        `import a from "a";
+
+    expect(await sortAndFormatCode({ code, prettierParser: 'babel' }))
+        .toEqual(`import a from "a";
 import c from "c";
 import g from "g";
 import k from "k";
 import t from "t";
 import z from "z";
-`,
-    );
+`);
 });
 
+// Verifies duplicate imports are merged before the final code is emitted.
 test('merges duplicate imports correctly', async () => {
     const code = `import z from 'z';
 import c from 'c';
@@ -54,57 +108,208 @@ import {b, type Bee} from 'a';
 import type {C} from 'c';
 import type {See} from 'c';
 `;
-    const importNodes = getImportNodes(code, { plugins: ['typescript'] });
-    const sortedNodes = getSortedNodes(importNodes, {
-        importOrder: defaultImportOrder,
-        importOrderCombineTypeAndValueImports: true,
-        importOrderCaseSensitive: false,
-        importOrderSafeSideEffects: [],
-        hasAnyCustomGroupSeparatorsInImportOrder: false,
-        provideGapAfterTopOfFileComments: false,
-    });
-    const formatted = getCodeFromAst({
-        nodesToOutput: sortedNodes,
-        allOriginalImportNodes: importNodes,
-        originalCode: code,
-        directives: [],
-    });
-    expect(await format(formatted, { parser: 'typescript' })).toEqual(
-        `import a, { b, type Bee } from "a";
+
+    expect(
+        await sortAndFormatCode({
+            code,
+            parserOptions: { plugins: ['typescript'] },
+            prettierParser: 'typescript',
+        }),
+    ).toEqual(`import a, { b, type Bee } from "a";
 import c, { type C, type See } from "c";
 import g from "g";
 import k from "k";
 import t from "t";
 import z from "z";
-`,
-    );
+`);
 });
 
+// Verifies mixed assert/with syntax is preserved and normalized through generation.
 test('handles import attributes and assertions, converting to attributes when necessary', async () => {
     const code = `import z from 'z';
     import g from 'g' with { type: 'json' };
 import c from 'c' assert { type: 'json' };
 `;
-    const importNodes = getImportNodes(code, {
-        plugins: [['importAttributes', { deprecatedAssertSyntax: true }]],
-    });
-    const sortedNodes = getSortedNodes(importNodes, {
-        importOrder: defaultImportOrder,
-        importOrderCombineTypeAndValueImports: true,
-        importOrderCaseSensitive: false,
-        importOrderSafeSideEffects: [],
-        hasAnyCustomGroupSeparatorsInImportOrder: false,
-        provideGapAfterTopOfFileComments: false,
-    });
-    const formatted = getCodeFromAst({
-        nodesToOutput: sortedNodes,
-        originalCode: code,
-        directives: [],
-    });
-    expect(await format(formatted, { parser: 'babel' })).toEqual(
-        `import c from "c" with { type: "json" };
+
+    expect(
+        await sortAndFormatCode({
+            code,
+            parserOptions: {
+                plugins: [
+                    ['importAttributes', { deprecatedAssertSyntax: true }],
+                ],
+            },
+            prettierParser: 'babel',
+        }),
+    ).toEqual(`import c from "c" with { type: "json" };
 import g from "g" with { type: "json" };
 import z from "z";
-`,
-    );
+`);
+});
+
+// Verifies leading file comments stay attached above the rewritten import block.
+test('sorts imports with leading comments', () => {
+    const code = `// leading comment
+
+import z from 'z';
+import a from 'a';
+
+const value = 1;
+`;
+
+    expect(sortCode({ code })).toBe(`;
+// leading comment
+
+import a from 'a';
+import z from 'z';
+
+const value = 1;
+`);
+});
+
+// Verifies extra blank lines left in the untouched remainder collapse to one import boundary gap.
+test('collapses leftover blank lines after rewritten imports', () => {
+    const code = `import z from 'z';
+import a from 'a';
+
+
+
+const value = 1;
+`;
+
+    expect(sortCode({ code })).toBe(`import a from 'a';
+import z from 'z';
+
+const value = 1;
+`);
+});
+
+// Verifies boundary cleanup removes only blank lines and not indentation on the next real line.
+test('preserves indentation on the first non-empty line after imports', () => {
+    const code = `import z from 'z';
+import a from 'a';
+
+
+    const value = 1;
+`;
+
+    expect(sortCode({ code })).toBe(`import a from 'a';
+import z from 'z';
+
+    const value = 1;
+`);
+});
+
+// Verifies synthetic separator markers become a single blank line between import groups.
+test('keeps a single blank line between separated import groups', () => {
+    const code = `import b from './b';
+import z from 'z';
+import a from 'a';
+
+const value = 1;
+`;
+
+    expect(sortCode({ code, importOrder: separatedImportOrder }))
+        .toBe(`import a from 'a';
+import z from 'z';
+
+import b from './b';
+
+const value = 1;
+`);
+});
+
+// Verifies import-only files do not keep an extra trailing blank-line run at EOF.
+test('does not leave trailing blank lines in import-only files with separated groups', () => {
+    const code = `import b from './b';
+import z from 'z';
+import a from 'a';
+`;
+
+    expect(sortCode({ code, importOrder: separatedImportOrder }))
+        .toBe(`import a from 'a';
+import z from 'z';
+
+import b from './b';
+`);
+});
+
+// Verifies directives remain at the top and imports are reinserted after them correctly.
+test('reinserts imports correctly when directives make injectIdx non-zero', () => {
+    const code = `'use client'
+import z from 'z';
+import a from 'a';
+
+const value=1;
+`;
+
+    expect(sortCode({ code })).toBe(`'use client';
+
+import a from 'a';
+import z from 'z';
+
+const value=1;
+`);
+});
+
+// Verifies grouped-import separators are preserved even when directives precede the imports.
+test('keeps separated groups after directives when injectIdx is non-zero', () => {
+    const code = `'use client'
+import b from './b';
+import z from 'z';
+import a from 'a';
+
+const value=1;
+`;
+
+    expect(sortCode({ code, importOrder: separatedImportOrder }))
+        .toBe(`'use client';
+
+import a from 'a';
+import z from 'z';
+
+import b from './b';
+
+const value=1;
+`);
+});
+
+// Verifies side-effect chunks keep exactly one separator on both sides after rewriting.
+test('keeps single separators around side-effect chunks', () => {
+    const code = `import b from './b';
+import './styles.css';
+import z from 'z';
+import a from 'a';
+
+const value = 1;
+`;
+
+    expect(sortCode({ code, importOrder: separatedImportOrder }))
+        .toBe(`import b from './b';
+
+import './styles.css';
+
+import a from 'a';
+import z from 'z';
+
+const value = 1;
+`);
+});
+
+// Verifies side-effect chunk output at EOF does not retain extra trailing blank lines.
+test('does not leave trailing blank lines at EOF for side-effect chunks', () => {
+    const code = `import b from './b';
+import './styles.css';
+import z from 'z';
+import a from 'a';
+`;
+
+    expect(sortCode({ code, importOrder: separatedImportOrder }))
+        .toBe(`import b from './b';
+
+import './styles.css';
+
+import a from 'a';
+import z from 'z';
+`);
 });

--- a/src/utils/__tests__/get-code-from-ast.spec.ts
+++ b/src/utils/__tests__/get-code-from-ast.spec.ts
@@ -167,8 +167,8 @@ const value = 1;
 `);
 });
 
-// Verifies extra blank lines left in the untouched remainder collapse to one import boundary gap.
-test('collapses leftover blank lines after rewritten imports', () => {
+// Verifies extra blank lines from the original import boundary are preserved instead of collapsed away.
+test('preserves extra blank lines after rewritten imports', () => {
     const code = `import z from 'z';
 import a from 'a';
 
@@ -180,11 +180,13 @@ const value = 1;
     expect(sortCode({ code })).toBe(`import a from 'a';
 import z from 'z';
 
+
+
 const value = 1;
 `);
 });
 
-// Verifies boundary cleanup removes only blank lines and not indentation on the next real line.
+// Verifies boundary cleanup preserves both the original extra gap and the indentation on the next real line.
 test('preserves indentation on the first non-empty line after imports', () => {
     const code = `import z from 'z';
 import a from 'a';
@@ -195,6 +197,7 @@ import a from 'a';
 
     expect(sortCode({ code })).toBe(`import a from 'a';
 import z from 'z';
+
 
     const value = 1;
 `);

--- a/src/utils/get-code-from-ast.ts
+++ b/src/utils/get-code-from-ast.ts
@@ -6,9 +6,20 @@ import {
     type Statement,
 } from '@babel/types';
 
-import { injectNewlinesRegex, newLineCharacters } from '../constants';
+import {
+    newLineCharacters,
+    PRETTIER_PLUGIN_SORT_IMPORTS_NEW_LINE,
+} from '../constants';
 import { getAllCommentsFromNodes } from './get-all-comments-from-nodes';
 import { removeNodesFromOriginalCode } from './remove-nodes-from-original-code';
+
+const generatedImportSeparatorRegex = new RegExp(
+    `(^|\\r?\\n)(?:"${PRETTIER_PLUGIN_SORT_IMPORTS_NEW_LINE}";(?:\\r?\\n|$))+`,
+    'g',
+);
+
+const leadingBlankLinesRegex = /^(?:[ \t]*\r?\n)+/;
+const trailingBlankLinesAtEofRegex = /(?:\r?\n[ \t]*)+$/;
 
 /**
  * This function generates a code string from the passed nodes.
@@ -53,31 +64,88 @@ export const getCodeFromAst = ({
         originalCode,
         nodesToRemoveFromCode,
     );
+    const updatedImports = replaceGeneratedImportSeparators(
+        createCodeFromAST({
+            body: nodesToOutput,
+            directives,
+            interpreter,
+        }),
+    );
 
-    const newAST = file({
-        type: 'Program',
-        body: nodesToOutput,
-        directives: directives,
-        sourceType: 'module',
-        interpreter: interpreter,
-        leadingComments: [],
-        innerComments: [],
-        trailingComments: [],
-        start: 0,
-        end: 0,
-        loc: {
-            start: { line: 0, column: 0, index: 0 },
-            end: { line: 0, column: 0, index: 0 },
-            filename: '',
-            identifierName: '',
-        },
+    const { injectIdx, updatedCode } = assembleUpdatedCode({
+        updatedImports,
+        codeWithoutImportsAndInterpreter,
     });
+    const updatedImportsEnd = injectIdx + updatedImports.length;
 
-    const { code } = generate(newAST, { importAttributesKeyword: 'with' });
+    return normalizeImportBoundary(updatedCode, updatedImportsEnd);
+};
 
-    const replacedCode = code.replace(injectNewlinesRegex, newLineCharacters);
+const createCodeFromAST = ({
+    body,
+    directives = [],
+    interpreter,
+}: {
+    body: Statement[];
+    directives?: Directive[];
+    interpreter?: InterpreterDirective | null;
+}) =>
+    generate(
+        file({
+            type: 'Program',
+            body,
+            directives,
+            sourceType: 'module',
+            interpreter,
+            leadingComments: [],
+            innerComments: [],
+            trailingComments: [],
+            start: 0,
+            end: 0,
+            loc: {
+                start: { line: 0, column: 0, index: 0 },
+                end: { line: 0, column: 0, index: 0 },
+                filename: '',
+                identifierName: '',
+            },
+        }),
+        { importAttributesKeyword: 'with' },
+    ).code;
 
-    const trailingCode = codeWithoutImportsAndInterpreter.trim();
+const replaceGeneratedImportSeparators = (code: string) =>
+    code.replace(
+        generatedImportSeparatorRegex,
+        (_match: string, linePrefix: string, offset: number) =>
+            offset === 0 && linePrefix === '' ? '' : newLineCharacters,
+    );
 
-    return replacedCode + trailingCode;
+const assembleUpdatedCode = ({
+    updatedImports,
+    codeWithoutImportsAndInterpreter,
+}: {
+    updatedImports: string;
+    codeWithoutImportsAndInterpreter: string;
+}) => {
+    return {
+        injectIdx: 0,
+        updatedCode: updatedImports + codeWithoutImportsAndInterpreter,
+    };
+};
+
+const normalizeImportBoundary = (
+    updatedCode: string,
+    updatedImportsEnd: number,
+) => {
+    const beforeBoundary = updatedCode.slice(0, updatedImportsEnd);
+    const untouchedRemainder = updatedCode.slice(updatedImportsEnd);
+    const remainderWithoutLeadingBlankLines = untouchedRemainder.replace(
+        leadingBlankLinesRegex,
+        '',
+    );
+
+    if (remainderWithoutLeadingBlankLines.trim().length === 0) {
+        return beforeBoundary.replace(trailingBlankLinesAtEofRegex, '\n');
+    }
+
+    return beforeBoundary + remainderWithoutLeadingBlankLines;
 };

--- a/src/utils/get-code-from-ast.ts
+++ b/src/utils/get-code-from-ast.ts
@@ -63,7 +63,7 @@ export const getCodeFromAst = ({
     const originalBoundaryLeadingBlankLines =
         getOriginalBoundaryLeadingBlankLines(
             originalCode,
-            nodesToRemoveFromCode,
+            allOriginalImportNodes,
         );
 
     const codeWithoutImportsAndInterpreter = removeNodesFromOriginalCode(
@@ -144,9 +144,9 @@ const assembleUpdatedCode = ({
 
 const getOriginalBoundaryLeadingBlankLines = (
     originalCode: string,
-    nodesToRemoveFromCode: Array<{ end?: number | null }>,
+    allOriginalImportNodes: Array<{ end?: number | null }>,
 ) => {
-    const boundaryEnd = nodesToRemoveFromCode.reduce(
+    const boundaryEnd = allOriginalImportNodes.reduce(
         (furthestEnd, node) =>
             typeof node.end === 'number'
                 ? Math.max(furthestEnd, node.end)

--- a/src/utils/get-code-from-ast.ts
+++ b/src/utils/get-code-from-ast.ts
@@ -19,7 +19,8 @@ const generatedImportSeparatorRegex = new RegExp(
 );
 
 const leadingBlankLinesRegex = /^(?:[ \t]*\r?\n)+/;
-const trailingBlankLinesAtEofRegex = /(?:\r?\n[ \t]*)+$/;
+const trailingLineBreaksRegex = /(?:[ \t]*\r?\n)+$/;
+const lineBreakUnitRegex = /[ \t]*\r?\n/g;
 
 /**
  * This function generates a code string from the passed nodes.
@@ -59,6 +60,11 @@ export const getCodeFromAst = ({
         ...(interpreter ? [interpreter] : []),
         ...directives,
     ];
+    const originalBoundaryLeadingBlankLines =
+        getOriginalBoundaryLeadingBlankLines(
+            originalCode,
+            nodesToRemoveFromCode,
+        );
 
     const codeWithoutImportsAndInterpreter = removeNodesFromOriginalCode(
         originalCode,
@@ -78,7 +84,11 @@ export const getCodeFromAst = ({
     });
     const updatedImportsEnd = injectIdx + updatedImports.length;
 
-    return normalizeImportBoundary(updatedCode, updatedImportsEnd);
+    return normalizeImportBoundary(
+        updatedCode,
+        updatedImportsEnd,
+        originalBoundaryLeadingBlankLines,
+    );
 };
 
 const createCodeFromAST = ({
@@ -132,20 +142,60 @@ const assembleUpdatedCode = ({
     };
 };
 
+const getOriginalBoundaryLeadingBlankLines = (
+    originalCode: string,
+    nodesToRemoveFromCode: Array<{ end?: number | null }>,
+) => {
+    const boundaryEnd = nodesToRemoveFromCode.reduce(
+        (furthestEnd, node) =>
+            typeof node.end === 'number'
+                ? Math.max(furthestEnd, node.end)
+                : furthestEnd,
+        0,
+    );
+
+    return (
+        originalCode.slice(boundaryEnd).match(leadingBlankLinesRegex)?.[0] ?? ''
+    );
+};
+
 const normalizeImportBoundary = (
     updatedCode: string,
     updatedImportsEnd: number,
+    originalBoundaryLeadingBlankLines: string,
 ) => {
     const beforeBoundary = updatedCode.slice(0, updatedImportsEnd);
     const untouchedRemainder = updatedCode.slice(updatedImportsEnd);
-    const remainderWithoutLeadingBlankLines = untouchedRemainder.replace(
+    const leadingBlankLines = untouchedRemainder.match(
         leadingBlankLinesRegex,
-        '',
+    )?.[0];
+
+    if (!leadingBlankLines) {
+        return updatedCode;
+    }
+
+    const remainderWithoutLeadingBlankLines = untouchedRemainder.slice(
+        leadingBlankLines.length,
     );
 
     if (remainderWithoutLeadingBlankLines.trim().length === 0) {
-        return beforeBoundary.replace(trailingBlankLinesAtEofRegex, '\n');
+        return beforeBoundary.replace(trailingLineBreaksRegex, '\n');
     }
 
-    return beforeBoundary + remainderWithoutLeadingBlankLines;
+    const trailingLineBreaks = beforeBoundary.match(
+        trailingLineBreaksRegex,
+    )?.[0];
+    const trailingLineBreakUnits =
+        trailingLineBreaks?.match(lineBreakUnitRegex) ?? [];
+    const originalBoundaryLineBreakUnits =
+        originalBoundaryLeadingBlankLines.match(lineBreakUnitRegex) ?? [];
+    const preservedLeadingLineBreaks = originalBoundaryLineBreakUnits
+        .slice(trailingLineBreakUnits.length)
+        .join('');
+
+    return (
+        beforeBoundary +
+        preservedLeadingLineBreaks +
+        remainderWithoutLeadingBlankLines
+    );
 };

--- a/tests/Range/range-formatting.spec.mjs
+++ b/tests/Range/range-formatting.spec.mjs
@@ -55,7 +55,7 @@ function expectSingleBlankLineBetween(code, before, after) {
     expectLineBreaksBetween(code, before, after, 2);
 }
 
-// Verifies partial Prettier formatting leaves exactly one blank line between imports and following code.
+// Verifies range formatting still rewrites imports when the selected range overlaps the import block.
 test('range formatting keeps one blank line after imports', async () => {
     const code = `import z from 'z';
 import a from 'a';
@@ -63,12 +63,14 @@ import a from 'a';
 const value=1;
 `;
 
+    const importsEnd = code.indexOf('\n\n') + 1;
     const output = await formatRange(code, {
-        rangeStart: code.indexOf('const'),
-        rangeEnd: code.length,
+        rangeStart: 0,
+        rangeEnd: importsEnd,
     });
 
-    expectSingleBlankLineBetween(output, "import z from 'z';", 'const value = 1;');
+    expect(output).toContain('import a from "a";');
+    expectSingleBlankLineBetween(output, 'import z from "z";', 'const value = 1;');
 });
 
 // Verifies the original single-import repro keeps only one blank line when the selected range ends at the import line.
@@ -123,7 +125,7 @@ test('range formatting preserves more than two leftover blank lines in the origi
     expect(output).toBe(code);
 });
 
-// Verifies range formatting preserves one separator between import groups and one before the next comment/code block.
+// Verifies grouped imports still normalize correctly when the selected range overlaps the import block.
 test('range formatting keeps one blank line between separated groups and before the next comment block', async () => {
     const code = `import b from './b';
 import z from 'z';
@@ -135,15 +137,15 @@ const value = 1;
 
     const output = await formatRange(code, {
         importOrder: separatedImportOrder,
-        rangeStart: code.indexOf('// next block'),
-        rangeEnd: code.length,
+        rangeStart: 0,
+        rangeEnd: code.indexOf('// next block'),
     });
 
-    expectSingleBlankLineBetween(output, "import z from 'z';", "import b from './b';");
-    expectSingleBlankLineBetween(output, "import b from './b';", '// next block');
+    expectSingleBlankLineBetween(output, 'import z from "z";', 'import b from "./b";');
+    expectSingleBlankLineBetween(output, 'import b from "./b";', '// next block');
 });
 
-// Verifies directives stay above the rewritten import block and the import/code boundary still collapses to one gap.
+// Verifies directives stay above the rewritten imports when the selected range includes the import block.
 test('range formatting keeps directives and one blank line after imports', async () => {
     const code = `'use client'
 import z from 'z';
@@ -153,14 +155,14 @@ const value=1;
 `;
 
     const output = await formatRange(code, {
-        rangeStart: code.indexOf('const'),
-        rangeEnd: code.length,
+        rangeStart: 0,
+        rangeEnd: code.indexOf('const'),
     });
 
-    expect(output.startsWith(`'use client';\n\nimport a from 'a';\n`)).toBe(
+    expect(output.startsWith(`"use client";\n\nimport a from "a";\n`)).toBe(
         true,
     );
-    expectSingleBlankLineBetween(output, "import z from 'z';", 'const value = 1;');
+    expectSingleBlankLineBetween(output, 'import z from "z";', 'const value = 1;');
 });
 
 // Verifies import rewriting still behaves when the selected range starts inside the import block itself.
@@ -181,21 +183,21 @@ const value=1;
     expectSingleBlankLineBetween(output, 'import z from "z";', 'const value = 1;');
 });
 
-// Verifies CRLF input plus range formatting still produces a single import/code separator.
+// Verifies CRLF input plus an overlapping import range still produces a single import/code separator.
 test('CRLF range formatting keeps exactly one blank line after imports', async () => {
     const code = "import z from 'z';\r\nimport a from 'a';\r\n\r\nconst value=1;\r\n";
 
     const output = await formatRange(code, {
         endOfLine: 'crlf',
-        rangeStart: code.indexOf('const'),
-        rangeEnd: code.length,
+        rangeStart: 0,
+        rangeEnd: code.indexOf('\r\n\r\n') + 1,
     });
 
     expect(output).toContain('\r\n');
-    expectSingleBlankLineBetween(output, "import z from 'z';", 'const value = 1;');
+    expectSingleBlankLineBetween(output, 'import z from "z";', 'const value = 1;');
 });
 
-// Verifies range formatting preserves one separator around unsortable side-effect chunks.
+// Verifies side-effect chunks still keep single separators when the selected range overlaps the import block.
 test('range formatting keeps one blank line around side-effect chunks', async () => {
     const code = `import b from './b';
 import './styles.css';
@@ -207,11 +209,11 @@ const value = 1;
 
     const output = await formatRange(code, {
         importOrder: separatedImportOrder,
-        rangeStart: code.indexOf('const value'),
-        rangeEnd: code.length,
+        rangeStart: 0,
+        rangeEnd: code.indexOf('const value'),
     });
 
-    expectSingleBlankLineBetween(output, "import b from './b';", "import './styles.css';");
-    expectSingleBlankLineBetween(output, "import './styles.css';", "import a from 'a';");
-    expectSingleBlankLineBetween(output, "import z from 'z';", 'const value = 1;');
+    expectSingleBlankLineBetween(output, 'import b from "./b";', 'import "./styles.css";');
+    expectSingleBlankLineBetween(output, 'import "./styles.css";', 'import a from "a";');
+    expectSingleBlankLineBetween(output, 'import z from "z";', 'const value = 1;');
 });

--- a/tests/Range/range-formatting.spec.mjs
+++ b/tests/Range/range-formatting.spec.mjs
@@ -1,0 +1,194 @@
+import { format } from 'prettier';
+import { expect, test } from 'vitest';
+
+import * as plugin from '../../src/index.ts';
+
+const defaultImportOrder = [
+    '<BUILTIN_MODULES>',
+    '<THIRD_PARTY_MODULES>',
+    '^[.]',
+];
+const separatedImportOrder = [
+    '<BUILTIN_MODULES>',
+    '',
+    '<THIRD_PARTY_MODULES>',
+    '',
+    '^[.]',
+];
+const angularSeparatedImportOrder = [
+    '^@angular(/.*)?$',
+    '',
+    '^primeng(/.*)?$',
+    '',
+    '<THIRD_PARTY_MODULES>',
+    '',
+    '^@app(/.*)?$',
+    '',
+    '^(\\.).*$',
+];
+
+async function formatRange(code, options = {}) {
+    return format(code, {
+        endOfLine: 'lf',
+        filepath: 'range-formatting.ts',
+        importOrder: defaultImportOrder,
+        importOrderSafeSideEffects: [],
+        parser: 'typescript',
+        plugins: [plugin],
+        ...options,
+    });
+}
+
+function expectSingleBlankLineBetween(code, before, after) {
+    const beforeIdx = code.indexOf(before);
+    expect(beforeIdx).toBeGreaterThanOrEqual(0);
+
+    const afterIdx = code.indexOf(after, beforeIdx + before.length);
+    expect(afterIdx).toBeGreaterThanOrEqual(0);
+
+    expect(code.slice(beforeIdx + before.length, afterIdx)).toMatch(
+        /^(?:\r?\n){2}$/,
+    );
+}
+
+// Verifies partial Prettier formatting leaves exactly one blank line between imports and following code.
+test('range formatting keeps one blank line after imports', async () => {
+    const code = `import z from 'z';
+import a from 'a';
+
+
+
+const value=1;
+`;
+
+    const output = await formatRange(code, {
+        rangeStart: code.indexOf('const'),
+        rangeEnd: code.length,
+    });
+
+    expectSingleBlankLineBetween(output, "import z from 'z';", 'const value=1;');
+});
+
+// Verifies the original single-import repro keeps only one blank line when the selected range ends at the import line.
+test('range formatting keeps one blank line for the original single-import repro', async () => {
+    const code = `import { Component, OnInit } from "@angular/core";
+
+//
+`;
+    const importEnd = code.indexOf('\n\n') + 1;
+
+    const output = await formatRange(code, {
+        importOrder: angularSeparatedImportOrder,
+        importOrderParserPlugins: [
+            'typescript',
+            'classProperties',
+            'decorators',
+        ],
+        importOrderTypeScriptVersion: '4.7.4',
+        rangeStart: 0,
+        rangeEnd: importEnd,
+    });
+
+    expect(output).toBe(`import { Component, OnInit } from "@angular/core";
+
+//
+`);
+});
+
+// Verifies range formatting preserves one separator between import groups and one before the next comment/code block.
+test('range formatting keeps one blank line between separated groups and before the next comment block', async () => {
+    const code = `import b from './b';
+import z from 'z';
+import a from 'a';
+
+
+
+// next block
+const value = 1;
+`;
+
+    const output = await formatRange(code, {
+        importOrder: separatedImportOrder,
+        rangeStart: code.indexOf('// next block'),
+        rangeEnd: code.length,
+    });
+
+    expectSingleBlankLineBetween(output, "import z from 'z';", "import b from './b';");
+    expectSingleBlankLineBetween(output, "import b from './b';", '// next block');
+});
+
+// Verifies directives stay above the rewritten import block and the import/code boundary still collapses to one gap.
+test('range formatting keeps directives and one blank line after imports', async () => {
+    const code = `'use client'
+import z from 'z';
+import a from 'a';
+
+
+const value=1;
+`;
+
+    const output = await formatRange(code, {
+        rangeStart: code.indexOf('const'),
+        rangeEnd: code.length,
+    });
+
+    expect(output.startsWith(`'use client';\n\nimport a from 'a';\n`)).toBe(
+        true,
+    );
+    expectSingleBlankLineBetween(output, "import z from 'z';", 'const value = 1;');
+});
+
+// Verifies import rewriting still behaves when the selected range starts inside the import block itself.
+test('range formatting still works when rangeStart begins inside the import block', async () => {
+    const code = `import z from 'z';
+import a from 'a';
+
+
+
+const value=1;
+`;
+
+    const output = await formatRange(code, {
+        rangeStart: code.indexOf(`'z'`),
+        rangeEnd: code.length,
+    });
+
+    expect(output).toContain("import a from 'a';");
+    expectSingleBlankLineBetween(output, "import z from 'z';", 'const value=1;');
+});
+
+// Verifies CRLF input plus range formatting still produces a single import/code separator.
+test('CRLF range formatting keeps exactly one blank line after imports', async () => {
+    const code = "import z from 'z';\r\nimport a from 'a';\r\n\r\n\r\nconst value=1;\r\n";
+
+    const output = await formatRange(code, {
+        endOfLine: 'crlf',
+        rangeStart: code.indexOf('const'),
+        rangeEnd: code.length,
+    });
+
+    expect(output).toContain('\r\n');
+    expectSingleBlankLineBetween(output, "import z from 'z';", 'const value=1;');
+});
+
+// Verifies range formatting preserves one separator around unsortable side-effect chunks.
+test('range formatting keeps one blank line around side-effect chunks', async () => {
+    const code = `import b from './b';
+import './styles.css';
+import z from 'z';
+import a from 'a';
+
+
+const value = 1;
+`;
+
+    const output = await formatRange(code, {
+        importOrder: separatedImportOrder,
+        rangeStart: code.indexOf('const value'),
+        rangeEnd: code.length,
+    });
+
+    expectSingleBlankLineBetween(output, "import b from './b';", "import './styles.css';");
+    expectSingleBlankLineBetween(output, "import './styles.css';", "import a from 'a';");
+    expectSingleBlankLineBetween(output, "import z from 'z';", 'const value = 1;');
+});

--- a/tests/Range/range-formatting.spec.mjs
+++ b/tests/Range/range-formatting.spec.mjs
@@ -39,7 +39,7 @@ async function formatRange(code, options = {}) {
     });
 }
 
-function expectSingleBlankLineBetween(code, before, after) {
+function expectLineBreaksBetween(code, before, after, lineBreakCount) {
     const beforeIdx = code.indexOf(before);
     expect(beforeIdx).toBeGreaterThanOrEqual(0);
 
@@ -47,16 +47,18 @@ function expectSingleBlankLineBetween(code, before, after) {
     expect(afterIdx).toBeGreaterThanOrEqual(0);
 
     expect(code.slice(beforeIdx + before.length, afterIdx)).toMatch(
-        /^(?:\r?\n){2}$/,
+        new RegExp(`^(?:\\r?\\n){${lineBreakCount}}$`),
     );
+}
+
+function expectSingleBlankLineBetween(code, before, after) {
+    expectLineBreaksBetween(code, before, after, 2);
 }
 
 // Verifies partial Prettier formatting leaves exactly one blank line between imports and following code.
 test('range formatting keeps one blank line after imports', async () => {
     const code = `import z from 'z';
 import a from 'a';
-
-
 
 const value=1;
 `;
@@ -66,7 +68,7 @@ const value=1;
         rangeEnd: code.length,
     });
 
-    expectSingleBlankLineBetween(output, "import z from 'z';", 'const value=1;');
+    expectSingleBlankLineBetween(output, "import z from 'z';", 'const value = 1;');
 });
 
 // Verifies the original single-import repro keeps only one blank line when the selected range ends at the import line.
@@ -95,13 +97,37 @@ test('range formatting keeps one blank line for the original single-import repro
 `);
 });
 
+// Verifies the import boundary keeps any extra blank lines that were already present after the original single-import repro.
+test('range formatting preserves more than two leftover blank lines in the original repro shape', async () => {
+    const code = `import { Component, OnInit } from "@angular/core";
+
+
+
+
+//
+`;
+    const importEnd = code.indexOf('\n\n') + 1;
+
+    const output = await formatRange(code, {
+        importOrder: angularSeparatedImportOrder,
+        importOrderParserPlugins: [
+            'typescript',
+            'classProperties',
+            'decorators',
+        ],
+        importOrderTypeScriptVersion: '4.7.4',
+        rangeStart: 0,
+        rangeEnd: importEnd,
+    });
+
+    expect(output).toBe(code);
+});
+
 // Verifies range formatting preserves one separator between import groups and one before the next comment/code block.
 test('range formatting keeps one blank line between separated groups and before the next comment block', async () => {
     const code = `import b from './b';
 import z from 'z';
 import a from 'a';
-
-
 
 // next block
 const value = 1;
@@ -123,7 +149,6 @@ test('range formatting keeps directives and one blank line after imports', async
 import z from 'z';
 import a from 'a';
 
-
 const value=1;
 `;
 
@@ -143,8 +168,6 @@ test('range formatting still works when rangeStart begins inside the import bloc
     const code = `import z from 'z';
 import a from 'a';
 
-
-
 const value=1;
 `;
 
@@ -153,13 +176,14 @@ const value=1;
         rangeEnd: code.length,
     });
 
-    expect(output).toContain("import a from 'a';");
-    expectSingleBlankLineBetween(output, "import z from 'z';", 'const value=1;');
+    expect(output).toContain('import a from "a";');
+    expect(output).toContain('import z from "z";');
+    expectSingleBlankLineBetween(output, 'import z from "z";', 'const value = 1;');
 });
 
 // Verifies CRLF input plus range formatting still produces a single import/code separator.
 test('CRLF range formatting keeps exactly one blank line after imports', async () => {
-    const code = "import z from 'z';\r\nimport a from 'a';\r\n\r\n\r\nconst value=1;\r\n";
+    const code = "import z from 'z';\r\nimport a from 'a';\r\n\r\nconst value=1;\r\n";
 
     const output = await formatRange(code, {
         endOfLine: 'crlf',
@@ -168,7 +192,7 @@ test('CRLF range formatting keeps exactly one blank line after imports', async (
     });
 
     expect(output).toContain('\r\n');
-    expectSingleBlankLineBetween(output, "import z from 'z';", 'const value=1;');
+    expectSingleBlankLineBetween(output, "import z from 'z';", 'const value = 1;');
 });
 
 // Verifies range formatting preserves one separator around unsortable side-effect chunks.
@@ -177,7 +201,6 @@ test('range formatting keeps one blank line around side-effect chunks', async ()
 import './styles.css';
 import z from 'z';
 import a from 'a';
-
 
 const value = 1;
 `;

--- a/tests/Range/range-overlap-gating.spec.mjs
+++ b/tests/Range/range-overlap-gating.spec.mjs
@@ -19,6 +19,13 @@ async function formatWithPlugin(code, options = {}) {
     });
 }
 
+async function formatWithoutSortPlugin(code, options = {}) {
+    return format(code, {
+        endOfLine: 'lf',
+        ...options,
+    });
+}
+
 function expectInOrder(code, firstNeedle, secondNeedle) {
     const firstIndex = code.indexOf(firstNeedle);
     const secondIndex = code.indexOf(secondNeedle);
@@ -63,18 +70,22 @@ const value=1;
 </template>
 `;
 
-    const output = await formatWithPlugin(code, {
+    const rangeOptions = {
         filepath: 'component.vue',
         parser: 'vue',
         rangeStart: code.indexOf('const value'),
         rangeEnd: code.indexOf('</script>'),
-    });
+    };
+    const output = await formatWithPlugin(code, rangeOptions);
+    const expected = await formatWithoutSortPlugin(code, rangeOptions);
 
+    expect(output).toBe(expected);
     expectInOrder(output, 'import z', 'import a');
     expect(output).not.toContain(`import a from "a";\nimport z from "z";`);
+    expect(output).toContain('const value = 1;');
 });
 
-// Verifies Ember template-tag files also leave imports alone when the partial range is below the import block.
+// Verifies Ember template-tag files leave imports alone while matching the upstream formatter output for the selected range.
 test('range formatting outside imports does not sort imports in ember template-tag files', async () => {
     const code = `import z from 'z';
 import a from 'a';
@@ -86,18 +97,26 @@ export default <template>
 </template>;
 `;
 
-    const output = await format(code, {
+    const rangeOptions = {
         endOfLine: 'lf',
         filepath: 'component.gjs',
+        parser: 'ember-template-tag',
+        rangeStart: code.indexOf('const value'),
+        rangeEnd: code.length,
+    };
+    const output = await format(code, {
+        ...rangeOptions,
         importOrder: defaultImportOrder,
         importOrderParserPlugins: ['jsx'],
         importOrderSafeSideEffects: [],
-        parser: 'ember-template-tag',
         plugins: ['prettier-plugin-ember-template-tag', plugin],
-        rangeStart: code.indexOf('const value'),
-        rangeEnd: code.length,
+    });
+    const expected = await formatWithoutSortPlugin(code, {
+        ...rangeOptions,
+        plugins: ['prettier-plugin-ember-template-tag'],
     });
 
+    expect(output).toBe(expected);
     expectInOrder(output, `import z from 'z';`, `import a from 'a';`);
     expect(output).not.toContain(`import a from 'a';\nimport z from 'z';`);
 });

--- a/tests/Range/range-overlap-gating.spec.mjs
+++ b/tests/Range/range-overlap-gating.spec.mjs
@@ -1,0 +1,103 @@
+import { format } from 'prettier';
+import { expect, test } from 'vitest';
+
+import * as plugin from '../../src/index.ts';
+
+const defaultImportOrder = [
+    '<BUILTIN_MODULES>',
+    '<THIRD_PARTY_MODULES>',
+    '^[.]',
+];
+
+async function formatWithPlugin(code, options = {}) {
+    return format(code, {
+        endOfLine: 'lf',
+        importOrder: defaultImportOrder,
+        importOrderSafeSideEffects: [],
+        plugins: [plugin],
+        ...options,
+    });
+}
+
+function expectInOrder(code, firstNeedle, secondNeedle) {
+    const firstIndex = code.indexOf(firstNeedle);
+    const secondIndex = code.indexOf(secondNeedle);
+
+    expect(firstIndex).toBeGreaterThanOrEqual(0);
+    expect(secondIndex).toBeGreaterThan(firstIndex);
+}
+
+// Verifies a partial range below imports leaves import order untouched in the default parser path.
+test('range formatting outside imports does not sort imports in typescript files', async () => {
+    const code = `import z from 'z';
+import a from 'a';
+
+const value=1;
+`;
+
+    const output = await formatWithPlugin(code, {
+        filepath: 'range-gating.ts',
+        parser: 'typescript',
+        rangeStart: code.indexOf('const'),
+        rangeEnd: code.length,
+    });
+
+    expect(output).toBe(`import z from 'z';
+import a from 'a';
+
+const value = 1;
+`);
+});
+
+// Verifies Vue skips import sorting when the selected range does not overlap script imports.
+test('range formatting outside imports does not sort imports in vue files', async () => {
+    const code = `<script setup>
+import z from 'z';
+import a from 'a';
+
+const value=1;
+</script>
+
+<template>
+  <div>{{ value }}</div>
+</template>
+`;
+
+    const output = await formatWithPlugin(code, {
+        filepath: 'component.vue',
+        parser: 'vue',
+        rangeStart: code.indexOf('const value'),
+        rangeEnd: code.indexOf('</script>'),
+    });
+
+    expectInOrder(output, 'import z', 'import a');
+    expect(output).not.toContain(`import a from "a";\nimport z from "z";`);
+});
+
+// Verifies Ember template-tag files also leave imports alone when the partial range is below the import block.
+test('range formatting outside imports does not sort imports in ember template-tag files', async () => {
+    const code = `import z from 'z';
+import a from 'a';
+
+const value=1;
+
+export default <template>
+  <div>{{value}}</div>
+</template>;
+`;
+
+    const output = await format(code, {
+        endOfLine: 'lf',
+        filepath: 'component.gjs',
+        importOrder: defaultImportOrder,
+        importOrderParserPlugins: ['jsx'],
+        importOrderSafeSideEffects: [],
+        parser: 'ember-template-tag',
+        plugins: ['prettier-plugin-ember-template-tag', plugin],
+        rangeStart: code.indexOf('const value'),
+        rangeEnd: code.length,
+    });
+
+    expectInOrder(output, `import z from 'z';`, `import a from 'a';`);
+    expect(output).not.toContain(`import a from 'a';\nimport z from 'z';`);
+});


### PR DESCRIPTION
> Built with Codex assistance.

## How the fix works

  Use this example:

  ```ts
  import z from "z";
  import a from "a";


  // next block
  const value = 1;
```

  Now imagine only the import area is being range-formatted.

  ### What the plugin wants to output

  After sorting, the desired result is:

  ```ts
  import a from "a";
  import z from "z";


  // next block
  const value = 1;
```

  That means:

  - imports are sorted
  - the blank line after imports is preserved

  ### What was going wrong before

  Inside the plugin, blank-line separators are represented by a synthetic marker node.

  Babel prints that marker as a real top-level line:

  ```ts
  import a from "a";
  import z from "z";
  "PRETTIER_PLUGIN_SORT_IMPORTS_NEW_LINE";
```

  At the same time, the plugin also preserved the original whitespace after the removed import block:

  ```ts
  \n\n// next block
  const value = 1;
```

  When those two pieces were joined together, the separator from the generated import block and the
  preserved whitespace from the original file could stack, producing extra blank lines:

  ```ts
  import a from "a";
  import z from "z";



  // next block
  const value = 1;
```

  That was the original bug.

  ### Commit 1

  This commit fixes the synthetic marker handling.

  Instead of leaving Babel’s printed marker line in place, it replaces each generated marker run with
  exactly one real separator:

  ```ts
  \n\n
```
  So the generated import block becomes:

  ```ts
  import a from "a";
  import z from "z";
```

  That removes one source of duplicate spacing, but it is not enough by itself.

  ### Commit 2

  This commit fixes the join between the rewritten imports and the untouched rest of the file.

  The remainder of the file may already begin with blank lines:

  ```ts
  \n\n// next block
  const value = 1;
```

  If that is appended directly to imports that already end with \n\n, the result still has too much
  space.

  So this commit changes the boundary logic to:

  - keep the separator emitted by the rewritten import block
  - remove only the duplicated overlap from the original remainder
  - preserve any extra spacing that already existed in the original file

  So the final result becomes:

  ```ts
  import a from "a";
  import z from "z";


  // next block
  const value = 1;
```

  ### Commit 3

  This commit changes when import sorting runs during range formatting.

  Example:

  ```ts
  import z from "z";
  import a from "a";

  const value = 1;
  console.log(value);
```
  If the selected range is only:

  ```ts
  console.log(value);
```

  imports should not be touched.

  Before this change, the plugin could still sort imports even when the formatted range did not overlap
  the import block.

  This commit adds overlap gating:

  - if the selected range does not touch imports, skip import sorting
  - if the selected range does touch imports, keep sorting imports as before

  So:

  - formatting unrelated code no longer changes imports
  - formatting imports still sorts them

  ### Commit 4

  This commit fixes a comment edge case.

  Example:

  ```ts
  import z from "z";
  import a from "a";


  // next block
  const value = 1;
```

  Babel may attach // next block to the last import.

  The spacing-preservation logic was measuring the original boundary from too far down, effectively
  from the attached comment instead of from the end of the last import. That caused the plugin to miss
  the original blank lines before the comment.

  This commit changes that behavior to:

  - measure the original boundary from the end of the last import
  - not from an attached comment node

  That makes spacing preservation work correctly for comment-adjacent boundaries too.

  ### Final behavior

  If the selected range overlaps imports:

  Input:

  ```ts
  import z from "z";
  import a from "a";


  // next block
  const value = 1;
```
  Output:
  ```ts
  import a from "a";
  import z from "z";


  // next block
  const value = 1;
```
  If the selected range does not overlap imports:

  ```ts
  const value = 1;
```

  imports remain unchanged.